### PR TITLE
Fixed rebuilding automatically on file changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "src/index.ts",
 	"type": "module",
 	"scripts": {
-		"dev": "nodemon --loader tsm .",
+		"dev": "nodemon --ext ts,js,mjs,json --legacy-watch --loader tsm .",
 		"start": "tsm ."
 	},
 	"license": "MIT",


### PR DESCRIPTION
It was simply a matter of specifying which extensions should be watched and switching to the legacy watcher instead.