### PR TITLE
Added the ability to solve threads using buttons

### DIFF
--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -10,7 +10,12 @@ import {
 	reopen_thread,
 } from '../utils/threads.js';
 import { no_op } from '../utils/promise.js';
-import { Message, MessageActionRow, MessageButton, MessageEditOptions } from 'discord.js';
+import {
+	Message,
+	MessageActionRow,
+	MessageButton,
+	MessageEditOptions,
+} from 'discord.js';
 
 export default command({
 	name: 'thread',
@@ -83,24 +88,25 @@ export default command({
 			}
 
 			case 'rename': {
-				// Get the new name from the interatction options, remove bloat from links and replace colons with semicolons
-				const new_name = interaction.options.getString('name', true)
+				// Get the new name from the interaction options, remove bloat from links and replace colons with semicolons
+				const new_name = interaction.options
+					.getString('name', true)
 					.replaceAll('http://', '')
 					.replaceAll('https://', '')
-					.replaceAll(':', ';')
+					.replaceAll(':', ';');
 				const parent_id = thread.parentId || '';
 
 				try {
 					// Make sure the new name isn't the same as the old one so rename calls aren't wasted
 					if (new_name === thread.name.slice(2))
 						throw new Error(
-							"The requested name was the same as the current name"
-						)
+							'The requested name was the same as the current name',
+						);
 					// Check if the command has reached the rename limit
 					if (rename_limit.is_limited(thread.id, true))
 						throw new Error(
-							"You can only rename a thread once every 10 minutes",
-						)
+							'You can only rename a thread once every 10 minutes',
+						);
 					// Rename the thread
 					await rename_thread(
 						thread,
@@ -108,21 +114,23 @@ export default command({
 						AUTO_THREAD_CHANNELS.includes(parent_id),
 					);
 					// Follow up the interaction
-					await interaction.followUp(wrap_in_embed('Thread renamed'))
-					// Delete the reply after 3 seconds
+					await interaction.followUp(wrap_in_embed('Thread renamed'));
+					// Delete the reply after 10 seconds
 					setTimeout(async () => {
 						await interaction.deleteReply();
-					}, 3000)
+					}, 10000);
 				} catch (e) {
 					// Send the error
-					const reply = await interaction.followUp(wrap_in_embed((e as Error).message)) as Message
-					// Delete the error after 5 seconds
+					const reply = (await interaction.followUp(
+						wrap_in_embed((e as Error).message),
+					)) as Message;
+					// Delete the error after 15 seconds
 					try {
 						setTimeout(async () => {
-							reply.delete()
-						}, 5000)
+							reply.delete();
+						}, 15000);
 					} catch (e) {
-						console.error(e)
+						console.error(e);
 					}
 				}
 				break;
@@ -134,42 +142,48 @@ export default command({
 					await solve_thread(thread);
 					// Successfully solved the thread
 					// Get the first message in the thread
-					const start_message = await thread.fetchStarterMessage()
+					const start_message = await thread.fetchStarterMessage();
 					// Get the first 2 messages after the start message
-					const messages = await thread.messages.fetch({ limit: 2, after: start_message.id })
+					const messages = await thread.messages.fetch({
+						limit: 2,
+						after: start_message.id,
+					});
 					// Filter the messages to find the bot message with the buttons
-					const bot_message = messages.filter(m => m.components.length > 0).first() as Message
+					const bot_message = messages
+						.filter((m) => m.components.length > 0)
+						.first() as Message;
 					// Change the message
 					const msg = wrap_in_embed(
 						'Thread solved. Thank you everyone! 🥳',
-					) as MessageEditOptions
+					) as MessageEditOptions;
 					// Change the button
-					const row = new MessageActionRow()
-						.addComponents(
-							new MessageButton()
-								.setCustomId('reopen')
-								.setLabel('Mark as Unsolved')
-								.setStyle('SECONDARY')
-								.setEmoji('❔'),
-						);
-					msg.components = [row]
-					await bot_message.edit(msg)
+					const row = new MessageActionRow().addComponents(
+						new MessageButton()
+							.setCustomId('reopen')
+							.setLabel('Mark as Unsolved')
+							.setStyle('SECONDARY')
+							.setEmoji('❔'),
+					);
+					msg.components = [row];
+					await bot_message.edit(msg);
 					// Commands require a reply
-					await interaction.followUp(wrap_in_embed('Thread solved.'))
-					// Delete the reply after 3 seconds
+					await interaction.followUp(wrap_in_embed('Thread solved.'));
+					// Delete the reply after 10 seconds
 					setTimeout(async () => {
 						await interaction.deleteReply();
-					}, 3000)
+					}, 10000);
 				} catch (e) {
 					// Send the error
-					const reply = await interaction.followUp(wrap_in_embed((e as Error).message)) as Message
-					// Delete the error after 5 seconds
+					const reply = (await interaction.followUp(
+						wrap_in_embed((e as Error).message),
+					)) as Message;
+					// Delete the error after 15 seconds
 					try {
 						setTimeout(async () => {
-							reply.delete()
-						}, 5000)
+							reply.delete();
+						}, 15000);
 					} catch (e) {
-						console.error(e)
+						console.error(e);
 					}
 				}
 				break;
@@ -181,42 +195,50 @@ export default command({
 					await reopen_thread(thread);
 					// Successfully reopened the thread
 					// Get the start message of the thread
-					const start_message = await thread.fetchStarterMessage()
+					const start_message = await thread.fetchStarterMessage();
 					// Get the first 2 messages after the start message
-					const messages = await thread.messages.fetch({ limit: 2, after: start_message.id })
+					const messages = await thread.messages.fetch({
+						limit: 2,
+						after: start_message.id,
+					});
 					// Filter to get the bot message with the button
-					const bot_message = messages.filter(m => m.components.length > 0).first() as Message
+					const bot_message = messages
+						.filter((m) => m.components.length > 0)
+						.first() as Message;
 					// Change the message
 					const msg = wrap_in_embed(
 						"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.",
-					) as MessageEditOptions
+					) as MessageEditOptions;
 					// Change the button
-					const row = new MessageActionRow()
-						.addComponents(
-							new MessageButton()
-								.setCustomId('solve')
-								.setLabel('Mark as Solved')
-								.setStyle('PRIMARY')
-								.setEmoji('✅'),
-						);
-					msg.components = [row]
-					await bot_message.edit(msg)
+					const row = new MessageActionRow().addComponents(
+						new MessageButton()
+							.setCustomId('solve')
+							.setLabel('Mark as Solved')
+							.setStyle('PRIMARY')
+							.setEmoji('✅'),
+					);
+					msg.components = [row];
+					await bot_message.edit(msg);
 					// Commands require a reply
-					await interaction.followUp(wrap_in_embed('Thread reopened.'))
-					// Delete the reply after 3 seconds
+					await interaction.followUp(
+						wrap_in_embed('Thread reopened.'),
+					);
+					// Delete the reply after 10 seconds
 					setTimeout(async () => {
 						await interaction.deleteReply();
-					}, 3000)
+					}, 10000);
 				} catch (e) {
 					// Send the error
-					const reply = await interaction.followUp(wrap_in_embed((e as Error).message)) as Message
-					// Delete the error after 5 seconds
+					const reply = (await interaction.followUp(
+						wrap_in_embed((e as Error).message),
+					)) as Message;
+					// Delete the error after 15 seconds
 					try {
 						setTimeout(async () => {
-							reply.delete()
-						}, 5000)
+							reply.delete();
+						}, 15000);
 					} catch (e) {
-						console.error(e)
+						console.error(e);
 					}
 				}
 				break;

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -1,28 +1,16 @@
 import { command } from 'jellycommands';
 import { AUTO_THREAD_CHANNELS } from '../config';
 import { wrap_in_embed } from '../utils/embed_helpers';
-import { RateLimitStore } from '../utils/ratelimit';
 import { get_member } from '../utils/snowflake';
 import {
-	add_thread_prefix,
 	check_autothread_permissions,
 	rename_thread,
 	solve_thread,
+	rename_limit,
+	reopen_thread,
 } from '../utils/threads.js';
 import { no_op } from '../utils/promise.js';
-
-/**
- * Discord allows 2 renames every 10 minutes. We need one always available
- * for the solve command, so only one rename per 10 minutes is allowed for users.
- */
-const rename_limit = new RateLimitStore(1, 10 * 60 * 1000);
-
-/*
- * This is mostly just to prevent abuse. We could reuse the rename limit but
- * highly unlikely it'll be legitimately closed and then reopened multiple
- * times in the same day.
- */
-const reopen_limit = new RateLimitStore(1, 1440 * 60 * 1000);
+import { Message, MessageActionRow, MessageButton, MessageEditOptions } from 'discord.js';
 
 export default command({
 	name: 'thread',
@@ -62,7 +50,7 @@ export default command({
 
 	global: true,
 	defer: {
-		ephemeral: true,
+		ephemeral: false,
 	},
 
 	run: async ({ interaction }) => {
@@ -95,83 +83,138 @@ export default command({
 			}
 
 			case 'rename': {
+				// Get the new name from the interatction options
 				const new_name = interaction.options.getString('name', true);
 				const parent_id = thread.parentId || '';
 
 				try {
+					// Make sure the new name isn't the same as the old one so rename calls aren't wasted
+					if (new_name === thread.name.slice(2))
+						throw new Error(
+							"The requested name was the same as the current name"
+						)
+					// Check if the command has reached the rename limit
 					if (rename_limit.is_limited(thread.id, true))
-						return await interaction.followUp(
-							'You can only rename a thread once every 10 minutes',
-						);
-
+						throw new Error(
+							"You can only rename a thread once every 10 minutes",
+						)
+					// Rename the thread
 					await rename_thread(
 						thread,
 						new_name,
 						AUTO_THREAD_CHANNELS.includes(parent_id),
 					);
-
-					await interaction.followUp('Thread renamed');
-				} catch (error) {
-					await interaction.followUp((error as Error).message);
+					// Follow up the interaction
+					await interaction.followUp(wrap_in_embed('Thread renamed'))
+					// Delete the reply after 3 seconds
+					setTimeout(async () => {
+						await interaction.deleteReply();
+					}, 3000)
+				} catch (e) {
+					// Send the error
+					const reply = await interaction.followUp(wrap_in_embed((e as Error).message)) as Message
+					// Delete the error after 5 seconds
+					try {
+						setTimeout(async () => {
+							reply.delete()
+						}, 5000)
+					} catch (e) {
+						console.error(e)
+					}
 				}
 				break;
 			}
 
 			case 'solve': {
 				try {
-					if (thread.name.startsWith('✅'))
-						throw new Error('Thread already marked as solved');
-
-					if (!AUTO_THREAD_CHANNELS.includes(thread.parentId || ''))
-						throw new Error(
-							'This command only works in a auto thread',
-						);
-
+					// Attempt to solve the thread
 					await solve_thread(thread);
-
-					await Promise.allSettled([
-						thread.send(
-							wrap_in_embed(
-								'Thread solved. Thank you everyone! 🥳',
-							),
-						),
-					]);
+					// Successfully solved the thread
+					// Get the first message in the thread
+					const start_message = await thread.fetchStarterMessage()
+					// Get the first 2 messages after the start message
+					const messages = await thread.messages.fetch({ limit: 2, after: start_message.id })
+					// Filter the messages to find the bot message with the buttons
+					const bot_message = messages.filter(m => m.components.length > 0).first() as Message
+					// Change the message
+					const msg = wrap_in_embed(
+						'Thread solved. Thank you everyone! 🥳',
+					) as MessageEditOptions
+					// Change the button
+					const row = new MessageActionRow()
+						.addComponents(
+							new MessageButton()
+								.setCustomId('reopen')
+								.setLabel('Mark as Unsolved')
+								.setStyle('SECONDARY')
+								.setEmoji('❔'),
+						);
+					msg.components = [row]
+					await bot_message.edit(msg)
+					// Commands require a reply
+					await interaction.followUp(wrap_in_embed('Thread solved.'))
+					// Delete the reply after 3 seconds
+					setTimeout(async () => {
+						await interaction.deleteReply();
+					}, 3000)
 				} catch (e) {
-					await interaction.followUp((e as Error).message);
+					// Send the error
+					const reply = await interaction.followUp(wrap_in_embed((e as Error).message)) as Message
+					// Delete the error after 5 seconds
+					try {
+						setTimeout(async () => {
+							reply.delete()
+						}, 5000)
+					} catch (e) {
+						console.error(e)
+					}
 				}
 				break;
 			}
 
 			case 'reopen':
 				try {
-					if (!thread.name.startsWith('✅'))
-						throw new Error("Thread's not marked as solved");
-
-					if (!AUTO_THREAD_CHANNELS.includes(thread.parentId || ''))
-						throw new Error(
-							'This command only works in a auto thread',
+					// Attempt to reopen the thread
+					await reopen_thread(thread);
+					// Successfully reopened the thread
+					// Get the start message of the thread
+					const start_message = await thread.fetchStarterMessage()
+					// Get the first 2 messages after the start message
+					const messages = await thread.messages.fetch({ limit: 2, after: start_message.id })
+					// Filter to get the bot message with the button
+					const bot_message = messages.filter(m => m.components.length > 0).first() as Message
+					// Change the message
+					const msg = wrap_in_embed(
+						"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.",
+					) as MessageEditOptions
+					// Change the button
+					const row = new MessageActionRow()
+						.addComponents(
+							new MessageButton()
+								.setCustomId('solve')
+								.setLabel('Mark as Solved')
+								.setStyle('PRIMARY')
+								.setEmoji('✅'),
 						);
-
-					if (reopen_limit.is_limited(thread.id, true))
-						throw new Error(
-							'You can only reopen a thread once every 24 hours',
-						);
-					if (rename_limit.is_limited(thread.id, true))
-						throw new Error(
-							"You'll have to wait at least 10 minutes from when you renamed the thread to reopen it.",
-						);
-
-					await thread.edit({
-						name: add_thread_prefix(thread.name, false).slice(
-							0,
-							100,
-						),
-						autoArchiveDuration: 1440,
-					});
-
-					await interaction.followUp('Thread reopened.');
+					msg.components = [row]
+					await bot_message.edit(msg)
+					// Commands require a reply
+					await interaction.followUp(wrap_in_embed('Thread reopened.'))
+					// Delete the reply after 3 seconds
+					setTimeout(async () => {
+						await interaction.deleteReply();
+					}, 3000)
 				} catch (e) {
-					await interaction.followUp((e as Error).message);
+					// Send the error
+					const reply = await interaction.followUp(wrap_in_embed((e as Error).message)) as Message
+					// Delete the error after 5 seconds
+					try {
+						setTimeout(async () => {
+							reply.delete()
+						}, 5000)
+					} catch (e) {
+						console.error(e)
+					}
 				}
 				break;
 		}

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -83,8 +83,11 @@ export default command({
 			}
 
 			case 'rename': {
-				// Get the new name from the interatction options
-				const new_name = interaction.options.getString('name', true);
+				// Get the new name from the interatction options, remove bloat from links and replace colons with semicolons
+				const new_name = interaction.options.getString('name', true)
+					.replaceAll('http://', '')
+					.replaceAll('https://', '')
+					.replaceAll(':', ';')
 				const parent_id = thread.parentId || '';
 
 				try {

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -32,10 +32,10 @@ export default event({
 						await interaction.update(msg)
 					} catch (e) {
 						// Send the error back to the user
-						const reply = await interaction.channel?.send(wrap_in_embed((e as Error).message))
+						await interaction.reply(wrap_in_embed((e as Error).message))
 						// Delete the error message after 5 seconds so it doesn't clutter the chat log
 						setTimeout(async () => {
-							await reply?.delete()
+							await interaction.deleteReply()
 						}, 5000)
 					}
 				}
@@ -60,13 +60,12 @@ export default event({
 						await interaction.update(msg)
 					} catch (e) {
 						// Send the error back to the user
-						const reply = await interaction.channel?.send(wrap_in_embed((e as Error).message))
+						await interaction.reply(wrap_in_embed((e as Error).message))
 						// Delete the error message after 5 seconds so it doesn't clutter the chat log
 						setTimeout(async () => {
-							await reply?.delete()
+							await interaction.deleteReply()
 						}, 5000)
 					}
-
 				}
 			}
 		}

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -1,0 +1,74 @@
+import { event } from 'jellycommands';
+import { reopen_thread, solve_thread } from '../utils/threads.js';
+import { ButtonInteraction, InteractionUpdateOptions, MessageActionRow, MessageButton, ThreadChannel } from 'discord.js';
+import { wrap_in_embed } from '../utils/embed_helpers.js';
+
+export default event({
+	name: 'interactionCreate',
+	run: async (_, interaction) => {
+		// When getting a ButtonInteraction
+		if (interaction instanceof ButtonInteraction) {
+			const channel = interaction.channel
+			// In a Thread channel
+			if (channel instanceof ThreadChannel) {
+				// A request to solve the thread received
+				if (interaction.customId === 'solve') {
+					try {
+						// Attempt to solve the channel
+						await solve_thread(channel)
+						// Successfully solved the channel, update the button
+						const msg = wrap_in_embed(
+							'Thread solved. Thank you everyone! 🥳',
+						) as InteractionUpdateOptions
+						const row = new MessageActionRow()
+							.addComponents(
+								new MessageButton()
+									.setCustomId('reopen')
+									.setLabel('Mark as Unsolved')
+									.setStyle('SECONDARY')
+									.setEmoji('❔'),
+							);
+						msg.components = [row]
+						await interaction.update(msg)
+					} catch (e) {
+						// Send the error back to the user
+						const reply = await interaction.channel?.send(wrap_in_embed((e as Error).message))
+						// Delete the error message after 5 seconds so it doesn't clutter the chat log
+						setTimeout(async () => {
+							await reply?.delete()
+						}, 5000)
+					}
+				}
+				// A request to reopen the thread received
+				if (interaction.customId === 'reopen') {
+					try {
+						// Attempt to reopen the channel
+						await reopen_thread(channel)
+						// Successfully reopened the channel, update the button
+						const msg = wrap_in_embed(
+							"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.",
+						) as InteractionUpdateOptions
+						const row = new MessageActionRow()
+							.addComponents(
+								new MessageButton()
+									.setCustomId('solve')
+									.setLabel('Mark as Solved')
+									.setStyle('PRIMARY')
+									.setEmoji('✅'),
+							);
+						msg.components = [row]
+						await interaction.update(msg)
+					} catch (e) {
+						// Send the error back to the user
+						const reply = await interaction.channel?.send(wrap_in_embed((e as Error).message))
+						// Delete the error message after 5 seconds so it doesn't clutter the chat log
+						setTimeout(async () => {
+							await reply?.delete()
+						}, 5000)
+					}
+
+				}
+			}
+		}
+	},
+});

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -1,6 +1,12 @@
 import { event } from 'jellycommands';
 import { reopen_thread, solve_thread } from '../utils/threads.js';
-import { ButtonInteraction, InteractionUpdateOptions, MessageActionRow, MessageButton, ThreadChannel } from 'discord.js';
+import {
+	ButtonInteraction,
+	InteractionUpdateOptions,
+	MessageActionRow,
+	MessageButton,
+	ThreadChannel,
+} from 'discord.js';
 import { wrap_in_embed } from '../utils/embed_helpers.js';
 
 export default event({
@@ -8,63 +14,65 @@ export default event({
 	run: async (_, interaction) => {
 		// When getting a ButtonInteraction
 		if (interaction instanceof ButtonInteraction) {
-			const channel = interaction.channel
+			const channel = interaction.channel;
 			// In a Thread channel
 			if (channel instanceof ThreadChannel) {
 				// A request to solve the thread received
 				if (interaction.customId === 'solve') {
 					try {
 						// Attempt to solve the channel
-						await solve_thread(channel)
+						await solve_thread(channel);
 						// Successfully solved the channel, update the button
 						const msg = wrap_in_embed(
 							'Thread solved. Thank you everyone! 🥳',
-						) as InteractionUpdateOptions
-						const row = new MessageActionRow()
-							.addComponents(
-								new MessageButton()
-									.setCustomId('reopen')
-									.setLabel('Mark as Unsolved')
-									.setStyle('SECONDARY')
-									.setEmoji('❔'),
-							);
-						msg.components = [row]
-						await interaction.update(msg)
+						) as InteractionUpdateOptions;
+						const row = new MessageActionRow().addComponents(
+							new MessageButton()
+								.setCustomId('reopen')
+								.setLabel('Mark as Unsolved')
+								.setStyle('SECONDARY')
+								.setEmoji('❔'),
+						);
+						msg.components = [row];
+						await interaction.update(msg);
 					} catch (e) {
 						// Send the error back to the user
-						await interaction.reply(wrap_in_embed((e as Error).message))
-						// Delete the error message after 5 seconds so it doesn't clutter the chat log
+						await interaction.reply(
+							wrap_in_embed((e as Error).message),
+						);
+						// Delete the error message after 15 seconds so it doesn't clutter the chat log
 						setTimeout(async () => {
-							await interaction.deleteReply()
-						}, 5000)
+							await interaction.deleteReply();
+						}, 15000);
 					}
 				}
 				// A request to reopen the thread received
 				if (interaction.customId === 'reopen') {
 					try {
 						// Attempt to reopen the channel
-						await reopen_thread(channel)
+						await reopen_thread(channel);
 						// Successfully reopened the channel, update the button
 						const msg = wrap_in_embed(
 							"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.",
-						) as InteractionUpdateOptions
-						const row = new MessageActionRow()
-							.addComponents(
-								new MessageButton()
-									.setCustomId('solve')
-									.setLabel('Mark as Solved')
-									.setStyle('PRIMARY')
-									.setEmoji('✅'),
-							);
-						msg.components = [row]
-						await interaction.update(msg)
+						) as InteractionUpdateOptions;
+						const row = new MessageActionRow().addComponents(
+							new MessageButton()
+								.setCustomId('solve')
+								.setLabel('Mark as Solved')
+								.setStyle('PRIMARY')
+								.setEmoji('✅'),
+						);
+						msg.components = [row];
+						await interaction.update(msg);
 					} catch (e) {
 						// Send the error back to the user
-						await interaction.reply(wrap_in_embed((e as Error).message))
-						// Delete the error message after 5 seconds so it doesn't clutter the chat log
+						await interaction.reply(
+							wrap_in_embed((e as Error).message),
+						);
+						// Delete the error message after 15 seconds so it doesn't clutter the chat log
 						setTimeout(async () => {
-							await interaction.deleteReply()
-						}, 5000)
+							await interaction.deleteReply();
+						}, 15000);
 					}
 				}
 			}

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -30,7 +30,7 @@ export default event({
 
 		await message.channel.threads
 			.create({
-				name: name.slice(0, 100),
+				name: name.length > 100 ? name.slice(0, 97) + '...' : name,
 				startMessage: message,
 			})
 			.then(send_instruction_message);

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,4 +1,4 @@
-import { Message, MessageOptions, ThreadChannel } from 'discord.js';
+import { Message, MessageOptions, MessageActionRow, MessageButton, ThreadChannel } from 'discord.js';
 import { event } from 'jellycommands';
 import url_regex from 'url-regex-safe';
 import { AUTO_THREAD_CHANNELS } from '../config';
@@ -8,7 +8,7 @@ import { get_title_from_url } from '../utils/unfurl';
 
 export default event({
 	name: 'messageCreate',
-	run: async ({}, message) => {
+	run: async ({ }, message) => {
 		const should_ignore =
 			message.author.bot ||
 			message.channel.type != 'GUILD_TEXT' ||
@@ -41,13 +41,25 @@ function get_thread_name(message: Message): string | Promise<string> {
 	return get_title_from_url(url[0]);
 }
 
-function send_instruction_message(thread: ThreadChannel) {
+async function send_instruction_message(thread: ThreadChannel) {
 	const base_description =
-		"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.";
+		"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it."
 
 	const description = AUTO_THREAD_CHANNELS.includes(thread.parentId!)
 		? `${base_description}\n\nWhen your problem is solved close the thread with the \`/thread solve\` command.`
 		: base_description;
 
-	return thread.send(wrap_in_embed(description) as MessageOptions);
+	// Add the solve button to the message
+	const msg = wrap_in_embed(description) as MessageOptions
+	const row = new MessageActionRow()
+		.addComponents(
+			new MessageButton()
+				.setCustomId('solve')
+				.setLabel('Mark as Solved')
+				.setStyle('PRIMARY')
+				.setEmoji('✅'),
+		);
+	msg.components = [row]
+
+	return await thread.send(msg);
 }

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,4 +1,10 @@
-import { Message, MessageOptions, MessageActionRow, MessageButton, ThreadChannel } from 'discord.js';
+import {
+	Message,
+	MessageOptions,
+	MessageActionRow,
+	MessageButton,
+	ThreadChannel,
+} from 'discord.js';
 import { event } from 'jellycommands';
 import url_regex from 'url-regex-safe';
 import { AUTO_THREAD_CHANNELS } from '../config';
@@ -9,7 +15,7 @@ import { Url } from 'url';
 
 export default event({
 	name: 'messageCreate',
-	run: async ({ }, message) => {
+	run: async ({}, message) => {
 		const should_ignore =
 			message.author.bot ||
 			message.channel.type != 'GUILD_TEXT' ||
@@ -22,7 +28,7 @@ export default event({
 		const raw_name = message.content
 			.replaceAll('http://', '')
 			.replaceAll('https://', '')
-			.replaceAll(':', ';')
+			.replaceAll(':', ';');
 
 		const name = AUTO_THREAD_CHANNELS.includes(message.channelId)
 			? add_thread_prefix(raw_name, false)
@@ -34,28 +40,27 @@ export default event({
 				startMessage: message,
 			})
 			.then(send_instruction_message);
-	}
+	},
 });
 
 async function send_instruction_message(thread: ThreadChannel) {
 	const base_description =
-		"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it."
+		"I've created a thread for your message. Please continue any discussion in this thread. You can rename it with the `/thread rename` command if I didn't set a proper name for it.";
 
 	const description = AUTO_THREAD_CHANNELS.includes(thread.parentId!)
 		? `${base_description}\n\nWhen your problem is solved close the thread with the \`/thread solve\` command.`
 		: base_description;
 
 	// Add the solve button to the message
-	const msg = wrap_in_embed(description) as MessageOptions
-	const row = new MessageActionRow()
-		.addComponents(
-			new MessageButton()
-				.setCustomId('solve')
-				.setLabel('Mark as Solved')
-				.setStyle('PRIMARY')
-				.setEmoji('✅'),
-		);
-	msg.components = [row]
+	const msg = wrap_in_embed(description) as MessageOptions;
+	const row = new MessageActionRow().addComponents(
+		new MessageButton()
+			.setCustomId('solve')
+			.setLabel('Mark as Solved')
+			.setStyle('PRIMARY')
+			.setEmoji('✅'),
+	);
+	msg.components = [row];
 
 	return await thread.send(msg);
 }

--- a/src/utils/threads.ts
+++ b/src/utils/threads.ts
@@ -40,7 +40,6 @@ export async function rename_thread(
 	use_prefix: boolean = true,
 ) {
 	const prefixed = add_thread_prefix(new_name, thread.name.startsWith('✅'));
-	console.log(prefixed)
 	await thread.setName((use_prefix ? prefixed : new_name).slice(0, 100));
 }
 

--- a/src/utils/threads.ts
+++ b/src/utils/threads.ts
@@ -40,6 +40,7 @@ export async function rename_thread(
 	use_prefix: boolean = true,
 ) {
 	const prefixed = add_thread_prefix(new_name, thread.name.startsWith('✅'));
+	console.log(prefixed)
 	await thread.setName((use_prefix ? prefixed : new_name).slice(0, 100));
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
 		"moduleResolution": "node",
 		"sourceMap": true,
 		"outDir": "dist",
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"lib": [
+		  "ES2021.String"
+		]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
All existing functionality is maintained with the /thread command, all that's been added is the ability to solve and reopen threads. 

Also includes various minor improvements and quality of life changes, primarily to the /thread command, such as responses being auto deleted and no longer stuck in the "Bot is thinking..." state.

Added comments to parts of the code.

Moved some of the /thread commands code into utils so that it can be easily called from the buttons.

Added wrapping of messages in embeds to some messages that previously weren't being wrapped.

Made messages such as solving the thread edit the existing bot message instead of sending new messages to avoid unnecessary clutter and enhance performance.