### PR TITLE
Added reply handling in auto thread channels

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -15,12 +15,24 @@ import { Url } from 'url';
 
 export default event({
 	name: 'messageCreate',
-	run: async ({}, message) => {
+	run: async ({ }, message) => {
 		const should_ignore =
 			message.author.bot ||
 			message.channel.type != 'GUILD_TEXT' ||
 			message.type != 'DEFAULT' ||
 			!AUTO_THREAD_CHANNELS.includes(message.channelId);
+
+		// If a response is sent by a user in an auto thread channel
+		if (message.type === 'REPLY' && AUTO_THREAD_CHANNELS.includes(message.channelId) && !message.author.bot) {
+			// Reply to their message with instructions
+			const response = await message.reply(wrap_in_embed("Please send responses in the issues thread and not directly in this channel"))
+			// Delete their message
+			await message.delete()
+			// Delete the response 5 seconds later
+			setTimeout(() => {
+				response.delete()
+			}, 5000)
+		}
 
 		if (should_ignore) return;
 

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -41,8 +41,13 @@ export default event({
 			const baseMessage = "Thanks for helping out! Please send you reply in the thread created for the issue and not directly in the channel."
 			// If the thread was found
 			if (thread) {
+				// Replicate the users message
+				const forwardMessage = {
+					content: `> Reply by <@${message.author.id}>:\n` + message.content,
+					files: message.attachments.map(x => x)
+				} as MessageOptions
 				// Send the message to the thread
-				await thread.send(`> Reply by <@${message.author.id}>:\n` + message.content)
+				await thread.send(forwardMessage)
 				// Create response message to the user with a link to the thread
 				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go directly to the thread:\n<#${thread.id}>`)
 			} else {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -58,7 +58,7 @@ export default event({
 			const response = await message.reply(msg)
 			// Delete their message
 			await message.delete()
-			// Delete the response 5 seconds later
+			// Delete the response 10 seconds later
 			setTimeout(() => {
 				response.delete()
 			}, 10000)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -4,6 +4,8 @@ import {
 	MessageActionRow,
 	MessageButton,
 	ThreadChannel,
+	ThreadManager,
+	TextChannel,
 } from 'discord.js';
 import { event } from 'jellycommands';
 import url_regex from 'url-regex-safe';
@@ -16,6 +18,7 @@ import { Url } from 'url';
 export default event({
 	name: 'messageCreate',
 	run: async ({ }, message) => {
+		// Rules for whether or not the message should be dealt with by the bot
 		const should_ignore =
 			message.author.bot ||
 			message.channel.type != 'GUILD_TEXT' ||
@@ -24,16 +27,44 @@ export default event({
 
 		// If a response is sent by a user in an auto thread channel
 		if (message.type === 'REPLY' && AUTO_THREAD_CHANNELS.includes(message.channelId) && !message.author.bot) {
-			// Reply to their message with instructions
-			const response = await message.reply(wrap_in_embed("Please send responses in the issues thread and not directly in this channel"))
+			// Get the channel as a TextChannel
+			const channel = message.channel as TextChannel
+			// Get the thread that the message refers to
+			let thread = channel.threads.cache.get(message.reference.messageId) as ThreadChannel
+			// If the thread wasn't found in the cache
+			if (!thread) {
+				// Get all active threads in the guild
+				const threads = (await message.guild.channels.fetchActiveThreads()).threads
+				// Get the thread
+				thread = threads.get(message.reference.messageId) as ThreadChannel
+			}
+			// Make msg available outside the if/else scope
+			let msg;
+			// If the thread was found
+			if (thread) {
+				// Create a message that mentions  the user
+				const usersMessage = wrap_in_embed(`Response by <@${message.author.id}>`) as MessageOptions
+				// Put their original message contents in the new message
+				usersMessage.content = message.content
+				// Send the message to the thread
+				await thread.send(usersMessage)
+				// Create response message to the user with a link to the thread
+				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel\n\n<#${thread.id}>`)
+			} else {
+				// Create response message to the user
+				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel`)
+			}
+			// Reply to the user
+			const response = await message.reply(msg)
 			// Delete their message
 			await message.delete()
 			// Delete the response 5 seconds later
 			setTimeout(() => {
 				response.delete()
-			}, 5000)
+			}, 10000)
 		}
 
+		// If the message should be ignored, return without further processing
 		if (should_ignore) return;
 
 		// Remove bloat from links and replace colons with semicolons

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -27,6 +27,8 @@ export default event({
 
 		// If a response is sent by a user in an auto thread channel
 		if (message.type === 'REPLY' && AUTO_THREAD_CHANNELS.includes(message.channelId) && !message.author.bot) {
+			// Delete their message
+			await message.delete()
 			// Get the channel as a TextChannel
 			const channel = message.channel as TextChannel
 			// Get the thread that the message refers to
@@ -45,23 +47,17 @@ export default event({
 				// Create a message that mentions  the user
 				const usersMessage = wrap_in_embed(`Response by <@${message.author.id}>`) as MessageOptions
 				// Put their original message contents in the new message
-				usersMessage.content = message.content
+				usersMessage.content = `Response by <@${message.author.id}>\n\n` + message.content
 				// Send the message to the thread
-				await thread.send(usersMessage)
+				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread
-				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel\n\n<#${thread.id}>`)
+				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
 			} else {
 				// Create response message to the user
-				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel`)
+				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.`)
 			}
-			// Reply to the user
-			const response = await message.reply(msg)
-			// Delete their message
-			await message.delete()
-			// Delete the response 10 seconds later
-			setTimeout(() => {
-				response.delete()
-			}, 10000)
+			// Send a DM to the user with the response message
+			await message.author.send(msg)
 		}
 
 		// If the message should be ignored, return without further processing

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -37,15 +37,17 @@ export default event({
 			}
 			// Make msg available outside the if/else scope
 			let msg;
+			// Base message text to send to the user
+			const baseMessage = "Please send responses in the thread created for the issue and not directly in the thread channel."
 			// If the thread was found
 			if (thread) {
 				// Send the message to the thread
 				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread
-				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
+				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
 			} else {
 				// Create response message to the user
-				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.`)
+				msg = wrap_in_embed(baseMessage)
 			}
 			// Send a DM to the user with the response message
 			await message.author.send(msg)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,19 +1,14 @@
 import {
-	Message,
 	MessageOptions,
 	MessageActionRow,
 	MessageButton,
 	ThreadChannel,
-	ThreadManager,
 	TextChannel,
 } from 'discord.js';
 import { event } from 'jellycommands';
-import url_regex from 'url-regex-safe';
 import { AUTO_THREAD_CHANNELS } from '../config';
 import { wrap_in_embed } from '../utils/embed_helpers';
 import { add_thread_prefix } from '../utils/threads';
-import { get_title_from_url } from '../utils/unfurl';
-import { Url } from 'url';
 
 export default event({
 	name: 'messageCreate',

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -39,10 +39,6 @@ export default event({
 			let msg;
 			// If the thread was found
 			if (thread) {
-				// Create a message that mentions  the user
-				const usersMessage = wrap_in_embed(`Response by <@${message.author.id}>`) as MessageOptions
-				// Put their original message contents in the new message
-				usersMessage.content = `Response by <@${message.author.id}>\n\n` + message.content
 				// Send the message to the thread
 				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -38,13 +38,13 @@ export default event({
 			// Make msg available outside the if/else scope
 			let msg;
 			// Base message text to send to the user
-			const baseMessage = "Please send responses in the thread created for the issue and not directly in the thread channel."
+			const baseMessage = "Thanks for helping out! Please send you reply in the thread created for the issue and not directly in the channel."
 			// If the thread was found
 			if (thread) {
 				// Send the message to the thread
-				await thread.send(`> Response from <@${message.author.id}>\n` + message.content)
+				await thread.send(`> Reply by <@${message.author.id}>:\n` + message.content)
 				// Create response message to the user with a link to the thread
-				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
+				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go directly to the thread:\n<#${thread.id}>`)
 			} else {
 				// Create response message to the user
 				msg = wrap_in_embed(baseMessage)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -42,7 +42,7 @@ export default event({
 			// If the thread was found
 			if (thread) {
 				// Send the message to the thread
-				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
+				await thread.send(`> Response from <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread
 				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
 			} else {


### PR DESCRIPTION
If the message is a response to another message in an auto thread channel it deletes the users message and show an instructional message, which is deleted 5 seconds later.