### PR TITLE
Added a /thread list command that lists active unsolved threads

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,6 @@
 	"bracketSpacing": true,
 	"arrowParens": "always",
 	"semi": true,
-	"useTabs": true,
+	"useTabs": false,
 	"tabWidth": 4
 }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This bot is based off of the amazing [Svelte Bot](https://github.com/pngwn/svelt
 -   `src/config.ts`: The bots main config is located at [src/config.ts](src/config.ts)
     -   `ADMIN_ROLES`: Role or user IDs that the bot will consider administrators
     -   `BOT_DEVS`: Currently the same functionality as `ADMIN_ROLES`
-    -   `HELP_CHANNELS`: Channel(s) to automatically thread any messages in (see the "Threads" functionality below)
-    -   `AUTO_THREAD_CHANNELS`: Currently the same values as `HELP_CHANNELS`
+    -   `AUTO_THREAD_CHANNELS`: Channel(s) that automatically thread any messages sent in them (extends `HELP_CHANNELS` below)
+    -   `HELP_CHANNELS`: Channel(s) that in addition to being auto threaded also come with issue handling capabilities
 
 ## Events
 
@@ -27,6 +27,8 @@ This bot is based off of the amazing [Svelte Bot](https://github.com/pngwn/svelt
     -   `/thread solve`: Removes ? and adds ✅ at the beginning of the thread name and sets the archive duration to 1hr
     -   `/thread archive`: Archive an active thread without marking it as solved
     -   `/thread reopen`: Reopen a thread that's been accidentally marked as solved
+-   `threads`: These are commands to manage all threads in the guild
+    -   `/threads list [filter]`: Lists currently active threads in the guild
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This bot is based off of the amazing [Svelte Bot](https://github.com/pngwn/svelt
     -   `/thread archive`: Archive an active thread without marking it as solved
     -   `/thread reopen`: Reopen a thread that's been accidentally marked as solved
 -   `threads`: These are commands to manage all threads in the guild
-    -   `/threads list [filter]`: Lists currently active threads in the guild
+    -   `/threads list`: Lists currently active threads in the channel the command was ran in
 
 ## Stack
 

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -94,15 +94,20 @@ export default command({
 				// Don't respond to the command wherever it was ran
 				await interaction.deleteReply();
 
-				// Get all active threads in the guild that the user has READ_MESSAGE_HISTORY access to
+				// Get all active non-private threads in the guild that the user has access to
 				const threads = (
 					await interaction.guild.channels.fetchActiveThreads()
 				).threads
 					.map((x) => x)
-					.filter((thread) =>
-						thread
-							.permissionsFor(interaction.user)
-							.has('READ_MESSAGE_HISTORY'),
+					.filter(
+						(thread) =>
+							!thread.isPrivate() &&
+							thread
+								.permissionsFor(interaction.user)
+								.has(
+									['READ_MESSAGE_HISTORY', 'VIEW_CHANNEL'],
+									false,
+								),
 					);
 
 				let message = '';
@@ -115,7 +120,7 @@ export default command({
 						// Set a title for the DM
 						message =
 							"**Here's a list of all currently active threads**\n";
-						// Add all unsolved threads to the message
+						// Add all threads to the message
 						message += threads
 							.map((thread) => `<#${thread.id}>`)
 							.join('\n');
@@ -125,7 +130,7 @@ export default command({
 						// Set a title for the DM
 						message =
 							"**Here's a list of all currently active chats**\n";
-						// Add all unsolved threads to the message
+						// Add all chat threads to the message
 						message += threads
 							.filter(
 								(val) =>
@@ -140,7 +145,7 @@ export default command({
 						// Set a title for the DM
 						message =
 							"**Here's a list of all currently active unsolved issues**\n";
-						// Add all unsolved threads to the message
+						// Add all unsolved issue threads to the message
 						message += threads
 							.filter((val) => val.name.startsWith('❔'))
 							.map((thread) => `<#${thread.id}>`)

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -29,32 +29,6 @@ export default command({
 			type: 'SUB_COMMAND',
 		},
 		{
-			name: 'list',
-			description: 'List all open threads',
-			type: 'SUB_COMMAND',
-			options: [
-				{
-					name: 'filter',
-					description: 'List open threads',
-					type: 'STRING',
-					choices: [
-						{
-							name: 'Active',
-							value: 'all',
-						},
-						{
-							name: 'Chats',
-							value: 'chats',
-						},
-						{
-							name: 'Unsolved issues',
-							value: 'unsolved_issues',
-						},
-					],
-				},
-			],
-		},
-		{
 			name: 'rename',
 			description: 'Rename a thread',
 			type: 'SUB_COMMAND',
@@ -117,74 +91,6 @@ export default command({
 					setTimeout(async () => {
 						await interaction.deleteReply();
 					}, 10000);
-					break;
-				}
-
-				case 'list': {
-					// Don't respond to the command wherever it was ran
-					await interaction.deleteReply();
-
-					// Get all active non-private threads in the guild that the user has access to
-					const threads = (
-						await interaction.guild.channels.fetchActiveThreads()
-					).threads
-						.map((x) => x)
-						.filter(
-							(thread) =>
-								!thread.isPrivate() &&
-								thread
-									.permissionsFor(interaction.user)
-									.has([
-										'READ_MESSAGE_HISTORY',
-										'VIEW_CHANNEL',
-									]),
-						);
-
-					let message = '';
-					// 'all', 'chats', 'unsolved_issues'
-					const filter = interaction.options.get('filter')
-						? interaction.options.get('filter').value
-						: 'all';
-					switch (filter) {
-						case 'all': {
-							// Set a title for the DM
-							message =
-								"**Here's a list of all currently active threads**\n";
-							// Add all threads to the message
-							message += threads
-								.map((thread) => `<#${thread.id}>`)
-								.join('\n');
-							break;
-						}
-						case 'chats': {
-							// Set a title for the DM
-							message =
-								"**Here's a list of all currently active chats**\n";
-							// Add all chat threads to the message
-							message += threads
-								.filter(
-									(val) =>
-										!val.name.startsWith('✅') &&
-										!val.name.startsWith('❔'),
-								)
-								.map((thread) => `<#${thread.id}>`)
-								.join('\n');
-							break;
-						}
-						case 'unsolved_issues': {
-							// Set a title for the DM
-							message =
-								"**Here's a list of all currently active unsolved issues**\n";
-							// Add all unsolved issue threads to the message
-							message += threads
-								.filter((val) => val.name.startsWith('❔'))
-								.map((thread) => `<#${thread.id}>`)
-								.join('\n');
-							break;
-						}
-					}
-					// Send the message to the user
-					await interaction.user.send(wrap_in_embed(message));
 					break;
 				}
 
@@ -268,7 +174,7 @@ export default command({
 					break;
 				}
 
-				case 'reopen':
+				case 'reopen': {
 					// Check if this is a help channel
 					if (!HELP_THREAD_CHANNELS.includes(thread.parentId)) {
 						throw new Error("Can't reopen a non-help channel");
@@ -310,6 +216,7 @@ export default command({
 						await interaction.deleteReply();
 					}, 10000);
 					break;
+				}
 			}
 		} catch (e) {
 			// Send the error

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -89,75 +89,6 @@ export default command({
 			const subcommand = interaction.options.getSubcommand(true);
 			const thread = await interaction.channel?.fetch();
 
-			// This command doesn't have to be run inside a thread nor does it require special permissions
-			if (subcommand === 'list') {
-				// Don't respond to the command wherever it was ran
-				await interaction.deleteReply();
-
-				// Get all active non-private threads in the guild that the user has access to
-				const threads = (
-					await interaction.guild.channels.fetchActiveThreads()
-				).threads
-					.map((x) => x)
-					.filter(
-						(thread) =>
-							!thread.isPrivate() &&
-							thread
-								.permissionsFor(interaction.user)
-								.has(
-									['READ_MESSAGE_HISTORY', 'VIEW_CHANNEL'],
-									false,
-								),
-					);
-
-				let message = '';
-				// 'all', 'chats', 'unsolved_issues'
-				const filter = interaction.options.get('filter')
-					? interaction.options.get('filter').value
-					: 'all';
-				switch (filter) {
-					case 'all': {
-						// Set a title for the DM
-						message =
-							"**Here's a list of all currently active threads**\n";
-						// Add all threads to the message
-						message += threads
-							.map((thread) => `<#${thread.id}>`)
-							.join('\n');
-						break;
-					}
-					case 'chats': {
-						// Set a title for the DM
-						message =
-							"**Here's a list of all currently active chats**\n";
-						// Add all chat threads to the message
-						message += threads
-							.filter(
-								(val) =>
-									!val.name.startsWith('✅') &&
-									!val.name.startsWith('❔'),
-							)
-							.map((thread) => `<#${thread.id}>`)
-							.join('\n');
-						break;
-					}
-					case 'unsolved_issues': {
-						// Set a title for the DM
-						message =
-							"**Here's a list of all currently active unsolved issues**\n";
-						// Add all unsolved issue threads to the message
-						message += threads
-							.filter((val) => val.name.startsWith('❔'))
-							.map((thread) => `<#${thread.id}>`)
-							.join('\n');
-						break;
-					}
-				}
-				// Send the message to the user
-				await interaction.user.send(wrap_in_embed(message));
-				return;
-			}
-
 			if (!thread?.isThread())
 				throw new Error('This channel is not a thread');
 
@@ -186,6 +117,74 @@ export default command({
 					setTimeout(async () => {
 						await interaction.deleteReply();
 					}, 10000);
+					break;
+				}
+
+				case 'list': {
+					// Don't respond to the command wherever it was ran
+					await interaction.deleteReply();
+
+					// Get all active non-private threads in the guild that the user has access to
+					const threads = (
+						await interaction.guild.channels.fetchActiveThreads()
+					).threads
+						.map((x) => x)
+						.filter(
+							(thread) =>
+								!thread.isPrivate() &&
+								thread
+									.permissionsFor(interaction.user)
+									.has([
+										'READ_MESSAGE_HISTORY',
+										'VIEW_CHANNEL',
+									]),
+						);
+
+					let message = '';
+					// 'all', 'chats', 'unsolved_issues'
+					const filter = interaction.options.get('filter')
+						? interaction.options.get('filter').value
+						: 'all';
+					switch (filter) {
+						case 'all': {
+							// Set a title for the DM
+							message =
+								"**Here's a list of all currently active threads**\n";
+							// Add all threads to the message
+							message += threads
+								.map((thread) => `<#${thread.id}>`)
+								.join('\n');
+							break;
+						}
+						case 'chats': {
+							// Set a title for the DM
+							message =
+								"**Here's a list of all currently active chats**\n";
+							// Add all chat threads to the message
+							message += threads
+								.filter(
+									(val) =>
+										!val.name.startsWith('✅') &&
+										!val.name.startsWith('❔'),
+								)
+								.map((thread) => `<#${thread.id}>`)
+								.join('\n');
+							break;
+						}
+						case 'unsolved_issues': {
+							// Set a title for the DM
+							message =
+								"**Here's a list of all currently active unsolved issues**\n";
+							// Add all unsolved issue threads to the message
+							message += threads
+								.filter((val) => val.name.startsWith('❔'))
+								.map((thread) => `<#${thread.id}>`)
+								.join('\n');
+							break;
+						}
+					}
+					// Send the message to the user
+					await interaction.user.send(wrap_in_embed(message));
 					break;
 				}
 
@@ -223,6 +222,7 @@ export default command({
 					}, 10000);
 					break;
 				}
+
 				case 'solve': {
 					// Check if this is a help channel
 					if (!HELP_THREAD_CHANNELS.includes(thread.parentId)) {

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -29,10 +29,14 @@ export default command({
 			type: 'SUB_COMMAND',
 		},
 		{
+			name: 'list',
+			description: 'List open threads',
+			type: 'SUB_COMMAND',
+		},
+		{
 			name: 'rename',
 			description: 'Rename a thread',
 			type: 'SUB_COMMAND',
-
 			options: [
 				{
 					name: 'name',
@@ -43,13 +47,13 @@ export default command({
 			],
 		},
 		{
-			name: 'solve',
-			description: 'Mark a thread as solved',
+			name: 'reopen',
+			description: 'Reopen a solved thread',
 			type: 'SUB_COMMAND',
 		},
 		{
-			name: 'reopen',
-			description: 'Reopen a solved thread',
+			name: 'solve',
+			description: 'Mark a thread as solved',
 			type: 'SUB_COMMAND',
 		},
 	],
@@ -63,6 +67,28 @@ export default command({
 		try {
 			const subcommand = interaction.options.getSubcommand(true);
 			const thread = await interaction.channel?.fetch();
+
+			// This command doesn't have to be run inside a thread nor does it require special permissions
+			if (subcommand === 'list') {
+				// Don't respond to the command wherever it was ran
+				await interaction.deleteReply();
+				// Get all active threads in the guild
+				const threads = (
+					await interaction.guild.channels.fetchActiveThreads()
+				).threads;
+				// Set a title for the DM
+				let message =
+					"**Here's a list of all currently active unsolved threads**\n";
+				// Add all unsolved threads to the message
+				message += threads
+					.map((x) => x)
+					.filter((val) => val.name.startsWith('❔'))
+					.map((thread) => `<#${thread.id}>`)
+					.join('\n');
+				// Send the message to the user
+				await interaction.user.send(message);
+				return;
+			}
 
 			if (!thread?.isThread())
 				throw new Error('This channel is not a thread');
@@ -129,7 +155,6 @@ export default command({
 					}, 10000);
 					break;
 				}
-
 				case 'solve': {
 					// Check if this is a help channel
 					if (!HELP_THREAD_CHANNELS.includes(thread.parentId)) {

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -71,7 +71,7 @@ export default command({
 			// This command doesn't have to be run inside a thread nor does it require special permissions
 			if (subcommand === 'list') {
 				// Don't respond to the command wherever it was ran
-				await interaction.deleteReply();
+				await interaction.deleteReply(); 
 				// Get all active threads in the guild
 				const threads = (
 					await interaction.guild.channels.fetchActiveThreads()
@@ -86,7 +86,7 @@ export default command({
 					.map((thread) => `<#${thread.id}>`)
 					.join('\n');
 				// Send the message to the user
-				await interaction.user.send(message);
+				await interaction.user.send(wrap_in_embed(message));
 				return;
 			}
 

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -23,14 +23,11 @@ export default command({
 					name: 'filter',
 					description: 'List open threads',
 					type: 'STRING',
+					required: true,
 					choices: [
 						{
 							name: 'Active',
 							value: 'active',
-						},
-						{
-							name: 'Chats',
-							value: 'chats',
 						},
 						{
 							name: 'Unsolved issues',
@@ -69,22 +66,12 @@ export default command({
 				case 'list':
 					{
 						let message = '';
-						// 'active', 'chats', 'unsolved_issues'
+						// 'active', 'unsolved_issues'
 						const filter = interaction.options.get('filter')
 							? interaction.options.get('filter').value
 							: 'active';
 						switch (filter) {
 							case 'active': {
-								// Set a title for the DM
-								message =
-									"**Here's a list of all currently active threads**\n";
-								// Add all threads to the message
-								message += threads
-									.map((thread) => `<#${thread.id}>`)
-									.join('\n');
-								break;
-							}
-							case 'chats': {
 								// Set a title for the DM
 								message =
 									"**Here's a list of all currently active chats**\n";

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -10,14 +10,7 @@ export default command({
 		{
 			name: 'list',
 			description: 'List all open threads',
-			type: 'SUB_COMMAND',
-			options: [
-				{
-					name: 'filter',
-					description: 'List open threads',
-					type: 'STRING',
-				},
-			],
+			type: 'SUB_COMMAND'
 		},
 	],
 

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -1,13 +1,6 @@
 import { command } from 'jellycommands';
-import { HELP_THREAD_CHANNELS } from '../config';
 import { wrap_in_embed } from '../utils/embed_helpers';
-import { reopen_thread } from '../utils/threads.js';
-import {
-	Message,
-	MessageActionRow,
-	MessageButton,
-	MessageEditOptions,
-} from 'discord.js';
+import { Message } from 'discord.js';
 
 export default command({
 	name: 'threads',

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -10,20 +10,18 @@ export default command({
 		{
 			name: 'list',
 			description: 'List all open threads',
-			type: 'SUB_COMMAND'
+			type: 'SUB_COMMAND',
 		},
 	],
 
 	global: true,
 	defer: {
-		ephemeral: false,
+		ephemeral: true,
 	},
 
 	run: async ({ interaction }) => {
 		try {
 			const subcommand = interaction.options.getSubcommand(true);
-			// Don't respond to the command wherever it was ran
-			await interaction.deleteReply();
 			// Get all active non-private threads in the guild that the user has access to
 			const threads = (
 				await interaction.guild.channels.fetchActiveThreads()
@@ -65,7 +63,7 @@ export default command({
 							.join('\n');
 					}
 					// Send the message to the user
-					await interaction.user.send(wrap_in_embed(message));
+					await interaction.followUp(wrap_in_embed(message));
 					break;
 				}
 			}

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -1,0 +1,175 @@
+import { command } from 'jellycommands';
+import { HELP_THREAD_CHANNELS } from '../config';
+import { wrap_in_embed } from '../utils/embed_helpers';
+import { reopen_thread } from '../utils/threads.js';
+import {
+	Message,
+	MessageActionRow,
+	MessageButton,
+	MessageEditOptions,
+} from 'discord.js';
+
+export default command({
+	name: 'threads',
+	description: 'Manage all threads',
+
+	options: [
+		{
+			name: 'list',
+			description: 'List all open threads',
+			type: 'SUB_COMMAND',
+			options: [
+				{
+					name: 'filter',
+					description: 'List open threads',
+					type: 'STRING',
+					choices: [
+						{
+							name: 'Active',
+							value: 'active',
+						},
+						{
+							name: 'Chats',
+							value: 'chats',
+						},
+						{
+							name: 'Unsolved issues',
+							value: 'unsolved_issues',
+						},
+					],
+				},
+			],
+		},
+	],
+
+	global: true,
+	defer: {
+		ephemeral: false,
+	},
+
+	run: async ({ interaction }) => {
+		try {
+			const subcommand = interaction.options.getSubcommand(true);
+			// Don't respond to the command wherever it was ran
+			await interaction.deleteReply();
+			// Get all active non-private threads in the guild that the user has access to
+			const threads = (
+				await interaction.guild.channels.fetchActiveThreads()
+			).threads
+				.map((x) => x)
+				.filter(
+					(thread) =>
+						!thread.isPrivate() &&
+						thread
+							.permissionsFor(interaction.user)
+							.has(['READ_MESSAGE_HISTORY', 'VIEW_CHANNEL']),
+				);
+
+			switch (subcommand) {
+				case 'list':
+					{
+						let message = '';
+						// 'active', 'chats', 'unsolved_issues'
+						const filter = interaction.options.get('filter')
+							? interaction.options.get('filter').value
+							: 'active';
+						switch (filter) {
+							case 'active': {
+								// Set a title for the DM
+								message =
+									"**Here's a list of all currently active threads**\n";
+								// Add all threads to the message
+								message += threads
+									.map((thread) => `<#${thread.id}>`)
+									.join('\n');
+								break;
+							}
+							case 'chats': {
+								// Set a title for the DM
+								message =
+									"**Here's a list of all currently active chats**\n";
+								// Add all chat threads to the message
+								message += threads
+									.filter(
+										(val) =>
+											!val.name.startsWith('✅') &&
+											!val.name.startsWith('❔'),
+									)
+									.map((thread) => `<#${thread.id}>`)
+									.join('\n');
+								break;
+							}
+							case 'unsolved_issues': {
+								// Set a title for the DM
+								message =
+									"**Here's a list of all currently active unsolved issues**\n";
+								// Add all unsolved issue threads to the message
+								message += threads
+									.filter((val) => val.name.startsWith('❔'))
+									.map((thread) => `<#${thread.id}>`)
+									.join('\n');
+								break;
+							}
+						}
+						// Send the message to the user
+						await interaction.user.send(wrap_in_embed(message));
+						break;
+					}
+					// Check if this is a help channel
+					if (!HELP_THREAD_CHANNELS.includes(thread.parentId)) {
+						throw new Error("Can't reopen a non-help channel");
+					}
+					// Attempt to reopen the thread
+					await reopen_thread(thread);
+					// Successfully reopened the thread
+					// Get the start message of the thread
+					const start_message = await thread.fetchStarterMessage();
+					// Get the first 2 messages after the start message
+					const messages = await thread.messages.fetch({
+						limit: 2,
+						after: start_message.id,
+					});
+					// Filter to get the bot message with the button
+					const bot_message = messages
+						.filter((m) => m.components.length > 0)
+						.first() as Message;
+					// Change the message
+					const msg = wrap_in_embed(
+						"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.",
+					) as MessageEditOptions;
+					// Change the button
+					const row = new MessageActionRow().addComponents(
+						new MessageButton()
+							.setCustomId('solve')
+							.setLabel('Mark as Solved')
+							.setStyle('PRIMARY')
+							.setEmoji('✅'),
+					);
+					msg.components = [row];
+					await bot_message.edit(msg);
+					// Commands require a reply
+					await interaction.followUp(
+						wrap_in_embed('Thread reopened.'),
+					);
+					// Delete the reply after 10 seconds
+					setTimeout(async () => {
+						await interaction.deleteReply();
+					}, 10000);
+					break;
+			}
+		} catch (e) {
+			// Send the error
+			const reply = (await interaction.followUp(
+				wrap_in_embed((e as Error).message),
+			)) as Message;
+			// Delete the error after 15 seconds
+			try {
+				setTimeout(async () => {
+					reply.delete();
+				}, 15000);
+			} catch (e) {
+				console.error(e);
+			}
+		}
+	},
+});


### PR DESCRIPTION
Adds a /thread list command that lists active unsolved threads

This variant sends links to the threads as a DM to the user who ran the command. It could be nicer to have them sent as an ephemeral message, but that would require creating a new command, something like /threads list. That solution might also be preferable from a code structure point of view, because currently this command has to have a separate if statement at the start in order to skip the permission checking that happens later that prevents the /thread command from being ran anywhere but inside a thread.

EDIT:
The command is now `/threads list [filter]`