### PR TITLE
Auto assist feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"express": "4.18.1",
 		"jellycommands": "1.0.0-next.31",
 		"ts-node": "10.9.1",
-		"tsm": "2.2.1",
+		"tsm": "2.2.2",
 		"unfurl.js": "5.7.0",
 		"url-regex-safe": "3.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"discord.js": "13.9.0",
+		"discord.js": "13.9.1",
 		"dotenv": "16.0.1",
 		"express": "4.18.1",
 		"jellycommands": "1.0.0-next.31",

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -163,6 +163,7 @@ export default command({
 							.setLabel('Mark as Unsolved')
 							.setStyle('SECONDARY')
 							.setEmoji('❔'),
+						...bot_message.components[0].components.filter(val => val.customId !== 'solve')
 					);
 					msg.components = [row];
 					await bot_message.edit(msg);
@@ -216,6 +217,7 @@ export default command({
 							.setLabel('Mark as Solved')
 							.setStyle('PRIMARY')
 							.setEmoji('✅'),
+						...bot_message.components[0].components.filter(val => val.customId !== 'reopen')
 					);
 					msg.components = [row];
 					await bot_message.edit(msg);

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -1,13 +1,16 @@
 import { event } from 'jellycommands';
-import { reopen_thread, solve_thread } from '../utils/threads.js';
+import { check_autothread_permissions, reopen_thread, solve_thread } from '../utils/threads.js';
 import {
 	ButtonInteraction,
 	InteractionUpdateOptions,
 	MessageActionRow,
 	MessageButton,
+	ModalSubmitInteraction,
 	ThreadChannel,
 } from 'discord.js';
 import { wrap_in_embed } from '../utils/embed_helpers.js';
+import { getAssistModal, getModal } from '../modals/index.js';
+import { get_member } from '../utils/snowflake.js';
 
 export default event({
 	name: 'interactionCreate',
@@ -17,24 +20,124 @@ export default event({
 			const channel = interaction.channel;
 			// In a Thread channel
 			if (channel instanceof ThreadChannel) {
-				// A request to solve the thread received
-				if (interaction.customId === 'solve') {
+				switch (interaction.customId) {
+					// A request to solve the thread received
+					case 'solve': {
+						try {
+							// Attempt to solve the channel
+							await solve_thread(channel);
+							// Successfully solved the channel, update the button
+							const msg = wrap_in_embed(
+								'Thread solved. Thank you everyone! 🥳',
+							) as InteractionUpdateOptions;
+							const row = new MessageActionRow().addComponents(
+								new MessageButton()
+									.setCustomId('reopen')
+									.setLabel('Mark as Unsolved')
+									.setStyle('SECONDARY')
+									.setEmoji('❔'),
+								...interaction.message.components[0].components.filter(val => val.customId !== 'solve')
+							);
+							msg.components = [row];
+							await interaction.update(msg);
+						} catch (e) {
+							// Send the error back to the user
+							await interaction.reply(
+								wrap_in_embed((e as Error).message),
+							);
+							// Delete the error message after 15 seconds so it doesn't clutter the chat log
+							setTimeout(async () => {
+								await interaction.deleteReply();
+							}, 15000);
+						}
+						break;
+					}
+					// A request to reopen the thread received
+					case 'reopen': {
+						try {
+							// Attempt to reopen the channel
+							await reopen_thread(channel);
+							// Successfully reopened the channel, update the button
+							const msg = wrap_in_embed(
+								"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.",
+							) as InteractionUpdateOptions;
+							const row = new MessageActionRow().addComponents(
+								new MessageButton()
+									.setCustomId('solve')
+									.setLabel('Mark as Solved')
+									.setStyle('PRIMARY')
+									.setEmoji('✅'),
+								...interaction.message.components[0].components.filter(val => val.customId !== 'reopen')
+							);
+							msg.components = [row];
+							await interaction.update(msg);
+						} catch (e) {
+							// Send the error back to the user
+							await interaction.reply(
+								wrap_in_embed((e as Error).message),
+							);
+							// Delete the error message after 15 seconds so it doesn't clutter the chat log
+							setTimeout(async () => {
+								await interaction.deleteReply();
+							}, 15000);
+						}
+						break;
+					}
+					// A request for automated assistance
+					case 'auto_assist': {
+						try {
+							// Find the member of the interaction user
+							const member = await get_member(interaction);
+							// Couldn't find the users member
+							if (!member) throw Error('Unable to find you')
+							// Check if the member has the proper permissions to interact with the bot	
+							const has_permission = await check_autothread_permissions(
+								channel,
+								member,
+							);
+							// Check if it has permissions
+							if (!has_permission)
+								throw Error(
+									"You don't have the permissions to manage this thread",
+								);
+							// Show the modal to the user
+							await interaction.showModal(getAssistModal('start').modal);
+						} catch (e) {
+							// Send the error back to the user
+							await interaction.reply(
+								wrap_in_embed((e as Error).message)
+							);
+							// Delete the error message after 15 seconds so it doesn't clutter the chat log
+							setTimeout(async () => {
+								await interaction.deleteReply();
+							}, 15000);
+						}
+						break;
+					}
+				}
+				// If the interaction id starts with auto_assist-
+				if (interaction.customId.startsWith('auto_assist-')) {
 					try {
-						// Attempt to solve the channel
-						await solve_thread(channel);
-						// Successfully solved the channel, update the button
-						const msg = wrap_in_embed(
-							'Thread solved. Thank you everyone! 🥳',
-						) as InteractionUpdateOptions;
-						const row = new MessageActionRow().addComponents(
-							new MessageButton()
-								.setCustomId('reopen')
-								.setLabel('Mark as Unsolved')
-								.setStyle('SECONDARY')
-								.setEmoji('❔'),
+						// Find the member of the interaction user
+						const member = await get_member(interaction);
+						// Couldn't find the users member
+						if (!member) throw Error('Unable to find you')
+						// Check if the member has the proper permissions to interact with the bot
+						const has_permission = await check_autothread_permissions(
+							channel,
+							member,
 						);
-						msg.components = [row];
-						await interaction.update(msg);
+						// Check if it has permissions
+						if (!has_permission)
+							throw Error(
+								"You don't have the permissions to manage this thread",
+							);
+						// Get the desired modal, e.g. auto_assist-start
+						const modal = getModal(interaction.customId.split('-').slice(0, 2).join('-'))
+						// Get the desired action, e.g. yes
+						const option = interaction.customId.split('-').slice(2).join('-')
+						// Run the action attached to the modal
+						await modal.options[option](interaction)
 					} catch (e) {
 						// Send the error back to the user
 						await interaction.reply(
@@ -46,34 +149,24 @@ export default event({
 						}, 15000);
 					}
 				}
-				// A request to reopen the thread received
-				if (interaction.customId === 'reopen') {
-					try {
-						// Attempt to reopen the channel
-						await reopen_thread(channel);
-						// Successfully reopened the channel, update the button
-						const msg = wrap_in_embed(
-							"I've created a thread for your message. Please continue any relevant discussion in this thread. You can rename it with the `/thread rename` command if I failed to set a proper name for it.",
-						) as InteractionUpdateOptions;
-						const row = new MessageActionRow().addComponents(
-							new MessageButton()
-								.setCustomId('solve')
-								.setLabel('Mark as Solved')
-								.setStyle('PRIMARY')
-								.setEmoji('✅'),
-						);
-						msg.components = [row];
-						await interaction.update(msg);
-					} catch (e) {
-						// Send the error back to the user
-						await interaction.reply(
-							wrap_in_embed((e as Error).message),
-						);
-						// Delete the error message after 15 seconds so it doesn't clutter the chat log
-						setTimeout(async () => {
-							await interaction.deleteReply();
-						}, 15000);
-					}
+			}
+		}
+		// If the interaction is a ModalSubmissionInteraction
+		if (interaction instanceof ModalSubmitInteraction) {
+			// And starts with auto_assist-
+			if (interaction.customId.startsWith('auto_assist-')) {
+				try {
+					// Get the appropriate modal and run its handler
+					await getModal(interaction.customId).run(interaction)
+				} catch (e) {
+					// Send the error back to the user
+					await interaction.reply(
+						wrap_in_embed((e as Error).message),
+					);
+					// Delete the error message after 15 seconds so it doesn't clutter the chat log
+					setTimeout(async () => {
+						await interaction.deleteReply();
+					}, 15000);
 				}
 			}
 		}

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -41,8 +41,13 @@ export default event({
 			const baseMessage = "Thanks for helping out! Please send you reply in the thread created for the issue and not directly in the channel."
 			// If the thread was found
 			if (thread) {
+				// Replicate the users message
+				const forwardMessage = {
+					content: `> Reply by <@${message.author.id}>:\n` + message.content,
+					files: message.attachments.map(x => x)
+				} as MessageOptions
 				// Send the message to the thread
-				await thread.send(`> Reply by <@${message.author.id}>:\n` + message.content)
+				await thread.send(forwardMessage)
 				// Create response message to the user with a link to the thread
 				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go directly to the thread:\n<#${thread.id}>`)
 			} else {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -23,6 +23,18 @@ export default event({
 			message.type != 'DEFAULT' ||
 			!AUTO_THREAD_CHANNELS.includes(message.channelId);
 
+		// If a response is sent by a user in an auto thread channel
+		if (message.type === 'REPLY' && AUTO_THREAD_CHANNELS.includes(message.channelId) && !message.author.bot) {
+			// Reply to their message with instructions
+			const response = await message.reply(wrap_in_embed("Please send responses in the issues thread and not directly in this channel"))
+			// Delete their message
+			await message.delete()
+			// Delete the response 5 seconds later
+			setTimeout(() => {
+				response.delete()
+			}, 5000)
+		}
+
 		if (should_ignore) return;
 
 		// Remove bloat from links and replace colons with semicolons

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -4,6 +4,7 @@ import {
 	MessageActionRow,
 	MessageButton,
 	ThreadChannel,
+	TextInputComponent,
 } from 'discord.js';
 import { event } from 'jellycommands';
 import url_regex from 'url-regex-safe';
@@ -15,7 +16,7 @@ import { Url } from 'url';
 
 export default event({
 	name: 'messageCreate',
-	run: async ({}, message) => {
+	run: async ({ }, message) => {
 		const should_ignore =
 			message.author.bot ||
 			message.channel.type != 'GUILD_TEXT' ||
@@ -51,7 +52,7 @@ async function send_instruction_message(thread: ThreadChannel) {
 		? `${base_description}\n\nWhen your problem is solved close the thread with the \`/thread solve\` command.`
 		: base_description;
 
-	// Add the solve button to the message
+	// Add the solve and bot assist buttons to the message
 	const msg = wrap_in_embed(description) as MessageOptions;
 	const row = new MessageActionRow().addComponents(
 		new MessageButton()
@@ -59,6 +60,11 @@ async function send_instruction_message(thread: ThreadChannel) {
 			.setLabel('Mark as Solved')
 			.setStyle('PRIMARY')
 			.setEmoji('✅'),
+		new MessageButton()
+			.setCustomId('auto_assist')
+			.setLabel('Ask the bot for help')
+			.setStyle('SECONDARY')
+			.setEmoji('🤖')
 	);
 	msg.components = [row];
 

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -37,15 +37,17 @@ export default event({
 			}
 			// Make msg available outside the if/else scope
 			let msg;
+			// Base message text to send to the user
+			const baseMessage = "Please send responses in the thread created for the issue and not directly in the thread channel."
 			// If the thread was found
 			if (thread) {
 				// Send the message to the thread
 				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread
-				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
+				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
 			} else {
 				// Create response message to the user
-				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.`)
+				msg = wrap_in_embed(baseMessage)
 			}
 			// Send a DM to the user with the response message
 			await message.author.send(msg)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,22 +1,19 @@
 import {
-	Message,
 	MessageOptions,
 	MessageActionRow,
 	MessageButton,
 	ThreadChannel,
-	TextInputComponent,
+	TextChannel,
 } from 'discord.js';
 import { event } from 'jellycommands';
-import url_regex from 'url-regex-safe';
 import { AUTO_THREAD_CHANNELS } from '../config';
 import { wrap_in_embed } from '../utils/embed_helpers';
 import { add_thread_prefix } from '../utils/threads';
-import { get_title_from_url } from '../utils/unfurl';
-import { Url } from 'url';
 
 export default event({
 	name: 'messageCreate',
 	run: async ({ }, message) => {
+		// Rules for whether or not the message should be dealt with by the bot
 		const should_ignore =
 			message.author.bot ||
 			message.channel.type != 'GUILD_TEXT' ||
@@ -25,16 +22,44 @@ export default event({
 
 		// If a response is sent by a user in an auto thread channel
 		if (message.type === 'REPLY' && AUTO_THREAD_CHANNELS.includes(message.channelId) && !message.author.bot) {
-			// Reply to their message with instructions
-			const response = await message.reply(wrap_in_embed("Please send responses in the issues thread and not directly in this channel"))
+			// Get the channel as a TextChannel
+			const channel = message.channel as TextChannel
+			// Get the thread that the message refers to
+			let thread = channel.threads.cache.get(message.reference.messageId) as ThreadChannel
+			// If the thread wasn't found in the cache
+			if (!thread) {
+				// Get all active threads in the guild
+				const threads = (await message.guild.channels.fetchActiveThreads()).threads
+				// Get the thread
+				thread = threads.get(message.reference.messageId) as ThreadChannel
+			}
+			// Make msg available outside the if/else scope
+			let msg;
+			// If the thread was found
+			if (thread) {
+				// Create a message that mentions  the user
+				const usersMessage = wrap_in_embed(`Response by <@${message.author.id}>`) as MessageOptions
+				// Put their original message contents in the new message
+				usersMessage.content = message.content
+				// Send the message to the thread
+				await thread.send(usersMessage)
+				// Create response message to the user with a link to the thread
+				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel\n\n<#${thread.id}>`)
+			} else {
+				// Create response message to the user
+				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel`)
+			}
+			// Reply to the user
+			const response = await message.reply(msg)
 			// Delete their message
 			await message.delete()
 			// Delete the response 5 seconds later
 			setTimeout(() => {
 				response.delete()
-			}, 5000)
+			}, 10000)
 		}
 
+		// If the message should be ignored, return without further processing
 		if (should_ignore) return;
 
 		// Remove bloat from links and replace colons with semicolons

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -53,7 +53,7 @@ export default event({
 			const response = await message.reply(msg)
 			// Delete their message
 			await message.delete()
-			// Delete the response 5 seconds later
+			// Delete the response 10 seconds later
 			setTimeout(() => {
 				response.delete()
 			}, 10000)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -22,6 +22,8 @@ export default event({
 
 		// If a response is sent by a user in an auto thread channel
 		if (message.type === 'REPLY' && AUTO_THREAD_CHANNELS.includes(message.channelId) && !message.author.bot) {
+			// Delete their message
+			await message.delete()
 			// Get the channel as a TextChannel
 			const channel = message.channel as TextChannel
 			// Get the thread that the message refers to
@@ -40,23 +42,17 @@ export default event({
 				// Create a message that mentions  the user
 				const usersMessage = wrap_in_embed(`Response by <@${message.author.id}>`) as MessageOptions
 				// Put their original message contents in the new message
-				usersMessage.content = message.content
+				usersMessage.content = `Response by <@${message.author.id}>\n\n` + message.content
 				// Send the message to the thread
-				await thread.send(usersMessage)
+				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread
-				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel\n\n<#${thread.id}>`)
+				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
 			} else {
 				// Create response message to the user
-				msg = wrap_in_embed(`Please send responses in the issues thread and not directly in this channel`)
+				msg = wrap_in_embed(`Please send responses in the thread created for the issue and not directly in the thread channel.`)
 			}
-			// Reply to the user
-			const response = await message.reply(msg)
-			// Delete their message
-			await message.delete()
-			// Delete the response 10 seconds later
-			setTimeout(() => {
-				response.delete()
-			}, 10000)
+			// Send a DM to the user with the response message
+			await message.author.send(msg)
 		}
 
 		// If the message should be ignored, return without further processing

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -39,10 +39,6 @@ export default event({
 			let msg;
 			// If the thread was found
 			if (thread) {
-				// Create a message that mentions  the user
-				const usersMessage = wrap_in_embed(`Response by <@${message.author.id}>`) as MessageOptions
-				// Put their original message contents in the new message
-				usersMessage.content = `Response by <@${message.author.id}>\n\n` + message.content
 				// Send the message to the thread
 				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -38,13 +38,13 @@ export default event({
 			// Make msg available outside the if/else scope
 			let msg;
 			// Base message text to send to the user
-			const baseMessage = "Please send responses in the thread created for the issue and not directly in the thread channel."
+			const baseMessage = "Thanks for helping out! Please send you reply in the thread created for the issue and not directly in the channel."
 			// If the thread was found
 			if (thread) {
 				// Send the message to the thread
-				await thread.send(`> Response from <@${message.author.id}>\n` + message.content)
+				await thread.send(`> Reply by <@${message.author.id}>:\n` + message.content)
 				// Create response message to the user with a link to the thread
-				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
+				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go directly to the thread:\n<#${thread.id}>`)
 			} else {
 				// Create response message to the user
 				msg = wrap_in_embed(baseMessage)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -42,7 +42,7 @@ export default event({
 			// If the thread was found
 			if (thread) {
 				// Send the message to the thread
-				await thread.send(`> Response by <@${message.author.id}>\n` + message.content)
+				await thread.send(`> Response from <@${message.author.id}>\n` + message.content)
 				// Create response message to the user with a link to the thread
 				msg = wrap_in_embed(`${baseMessage}\n\nClick this link to go to the thread you should respond in\n<#${thread.id}>`)
 			} else {

--- a/src/modals/assist/_template.ts
+++ b/src/modals/assist/_template.ts
@@ -1,0 +1,63 @@
+/*
+
+This is just a template for creating other modals
+
+*/
+
+import { Modal, TextInputComponent, MessageActionRow, ModalSubmitInteraction, MessageButton, InteractionReplyOptions, ButtonInteraction } from "discord.js";
+import { wrap_in_embed } from "../../utils/embed_helpers";
+import { MessageOptions } from "child_process";
+
+export const someUniqueModalName = {
+    // Create a modal to show to the user
+    modal: new Modal()
+        .setTitle('First the basics')
+        .addComponents(new MessageActionRow()
+            .addComponents(new TextInputComponent()
+                .setCustomId('tauri_info')
+                .setLabel("Output of the tauri info command")
+                .setStyle('PARAGRAPH'))),
+    run: function (interaction: ModalSubmitInteraction) {
+        // This function runs when the modal is submitted
+        // Create a message to send to the user
+        let msg = wrap_in_embed('Something') as InteractionReplyOptions
+        // Reply to the user
+        interaction.reply(msg)
+    },
+    options: {
+        'yes': async function (interaction: ButtonInteraction) {
+            // Create a message to send to the user
+            let msg = wrap_in_embed("The user clicked yes") as MessageOptions
+            // Send the message to the user
+            await interaction.channel.send(msg)
+            // Create a MessageRow where the chosen interaction is disabled
+            const origRow = new MessageActionRow().addComponents(
+                new MessageButton()
+                    .setCustomId('auto_assist-start-yes')
+                    .setLabel('Yes')
+                    .setStyle('SUCCESS')
+                    .setEmoji('✅')
+                    .setDisabled(true)
+            )
+            // Update the original interaction message to make it clear which option the user picked
+            await interaction.update({ components: [origRow] })
+        },
+        'no': async function (interaction: ButtonInteraction) {
+            // Create a message to send to the user
+            let msg = wrap_in_embed("The user clicked no") as MessageOptions
+            // Send the message to the user
+            await interaction.channel.send(msg)
+            // Create a MessageRow where the chosen interaction is disabled
+            const origRow = new MessageActionRow().addComponents(
+                new MessageButton()
+                    .setCustomId('auto_assist-start-no')
+                    .setLabel('No')
+                    .setStyle('DANGER')
+                    .setEmoji('⚠️')
+                    .setDisabled(true)
+            )
+            // Update the original interaction message to make it clear which option the user picked
+            await interaction.update({ components: [origRow] })
+        }
+    }
+}

--- a/src/modals/assist/start.ts
+++ b/src/modals/assist/start.ts
@@ -1,0 +1,267 @@
+import { Modal, TextInputComponent, MessageActionRow, ModalSubmitInteraction, MessageButton, InteractionReplyOptions, Message, ButtonInteraction, ThreadChannel, MessageEditOptions } from "discord.js";
+import { wrap_in_embed } from "../../utils/embed_helpers";
+import { solve_thread } from "../../utils/threads";
+import { MessageOptions } from "child_process";
+
+export const assistStartModal = {
+    // Create a modal to show to the user
+    modal: new Modal()
+        .setTitle('First the basics')
+        .addComponents(new MessageActionRow()
+            .addComponents(new TextInputComponent()
+                .setCustomId('tauri_info')
+                .setLabel("Output of the tauri info command")
+                .setStyle('PARAGRAPH'))),
+    // Used to process the modals submission
+    run: async function (interaction: ModalSubmitInteraction) {
+        // Stores all problems found
+        let problems: [Problem?] = []
+        // Current version of all dependencies (may need to find more and dynamically)
+        const currentVersion = '1.0.4'
+        // Get the tauri_info output from the modal
+        const tauriInfoText = interaction.fields.getTextInputValue('tauri_info')
+            .split('\n')
+            .map(v => v.trim())
+            .filter(v => v !== '')
+        // Used to store the tauri_info as an object
+        let tauriInfo: LooseObject = {
+            environment: {},
+            packages: {},
+            app: {}
+        }
+        // Current section being handled
+        let section = ''
+        tauriInfoText.forEach((val) => {
+            if (val === 'Environment') {
+                section = 'environment'
+                return
+            }
+            if (val === 'Packages') {
+                section = 'packages'
+                return
+            }
+            if (val === 'App') {
+                section = 'app'
+                return
+            }
+            if (val === 'App directory structure') {
+                section = 'appDirectoryStructure'
+                return
+            }
+            if (section === 'environment' && val.startsWith('›')) {
+                tauriInfo[section][val.slice(2).split(':')[0]] = val.slice(2).split(':').slice(1).join('').trim()
+            }
+            if (section === 'packages' && val.startsWith('›')) {
+                tauriInfo[section][val.slice(2).split(':')[0]] = val.slice(2).split(':').slice(1).join('').trim().replace(',', '')
+            }
+            if (section === 'app' && val.startsWith('›')) {
+                tauriInfo[section][val.slice(2).split(':')[0]] = val.slice(2).split(':').slice(1).join('').trim()
+            }
+            if (section === 'appDirectoryStructure' && val.startsWith('›')) {
+                // TODO: Analyze the directory structure
+            }
+        })
+
+        // Check if tauri and tauri-build are the same versions
+        if (tauriInfo.packages['tauri [RUST]'] && tauriInfo.packages['tauri [RUST]'] !== tauriInfo.packages['tauri-build [RUST]']) {
+            problems.push({
+                info: `Your \`tauri\` and \`tauri-build\` dependencies versions do not appear to match, make sure they are both using \`${currentVersion}\``,
+                solutions: ['Edit `Cargo.toml` that all versions are correct', 'Run `cargo update`']
+            })
+        }
+
+        // Check if the CLI is the latest version
+        if (tauriInfo.packages['@tauri-apps/cli [NPM]'] && tauriInfo.packages['@tauri-apps/cli [NPM]'] !== currentVersion && tauriInfo.packages['@tauri-apps/cli [NPM]'] !== 'Not installed!') {
+            problems.push({
+                info: `\`@tauri-apps/cli [NPM]\` appears to be outdated, your version is \`${tauriInfo.packages['@tauri-apps/cli [NPM]']}\`, the current version is \`${currentVersion}\``,
+                solutions: ['Run `yarn add @tauri-apps/cli`']
+            })
+        }
+
+        // Check if the API is the latest version
+        if (tauriInfo.packages['@tauri-apps/api [NPM]'] && tauriInfo.packages['@tauri-apps/api [NPM]'] !== currentVersion && tauriInfo.packages['@tauri-apps/api [NPM]'] !== 'Not installed!') {
+            problems.push({
+                info: `\`@tauri-apps/api\` [NPM] appears to be outdated, your version is \`${tauriInfo.packages['@tauri-apps/api [NPM]']}\`, the current version is \`${currentVersion}\``,
+                solutions: ['Run `yarn add @tauri-apps/api`']
+            })
+        }
+
+        // Check if tauri is the latest version
+        if (tauriInfo.packages['tauri [RUST]'] && tauriInfo.packages['tauri [RUST]'] !== currentVersion) {
+            problems.push({
+                info: `\`tauri [RUST]\` appears to be outdated, your version is \`${tauriInfo.packages['tauri [RUST]']}\`, the current version is \`${currentVersion}\``,
+                solutions: ['Run `cargo update`']
+            })
+        }
+
+        // Check if tauri-build is the latest version
+        if (tauriInfo.packages['tauri-build [RUST]'] && tauriInfo.packages['tauri-build [RUST]'] !== currentVersion) {
+            problems.push({
+                info: `\`tauri-build [RUST]\` appears to be outdated, your version is \`${tauriInfo.packages['tauri-build [RUST]']}\`, the current version is \`${currentVersion}\``,
+                solutions: ['Run `cargo update`']
+            })
+        }
+
+        // Store the response text
+        let text = ''
+        // Add Problems header
+        if (problems.length > 0) {
+            text = `${text}**Problems**`
+        }
+        const infos: [String?] = []
+        // Add problems
+        problems.forEach((val) => {
+            if (!infos.includes(val.info)) {
+                infos.push(val.info)
+                text = `${text}\n- ${val.info}`
+            }
+        })
+        // Add Solutions header
+        if (problems.length > 0) {
+            text = `${text}\n\n**Solutions**`
+        }
+        const solutions: [String?] = []
+        let counter = 0
+        // Add solutions
+        problems.forEach((val) => {
+            val.solutions.forEach((sol) => {
+                if (!solutions.includes(sol)) {
+                    counter += 1
+                    solutions.push(sol)
+                    text = `${text}\n${counter}. ${sol}`
+                }
+            })
+        })
+        if (text.length === 0) {
+            // If the text is still empty, there were no suggestions
+            text = 'Looks good as far as I can tell 🤷‍♂️\n\nClick *Continue* to move on to the next step.'
+        } else {
+            // If there was text we ask an appropriate question based on what the next buttons are
+            text = `${text}\n\n**Did this fix your issue?**`
+        }
+        // Create the response message
+        let msg = wrap_in_embed(text) as InteractionReplyOptions
+        // Create the MessageActionRow
+        const row = new MessageActionRow()
+        if (problems.length > 0) {
+            // If we had problems, add next options
+            row.addComponents(
+                new MessageButton()
+                    .setCustomId('auto_assist-start-yes')
+                    .setLabel('Yes')
+                    .setStyle('SUCCESS')
+                    .setEmoji('✅'),
+                new MessageButton()
+                    .setCustomId('auto_assist-start-no')
+                    .setLabel('No')
+                    .setStyle('DANGER')
+                    .setEmoji('⚠️'),
+            )
+        } else {
+            // If we didn't have any problems, let the user continue
+            row.addComponents(
+                new MessageButton()
+                    .setCustomId('auto_assist-start-continue')
+                    .setLabel('Continue')
+                    .setStyle('PRIMARY')
+                    .setEmoji('▶️'),
+            )
+        }
+        // Add the MessageActionRow
+        msg.components = [row];
+        // Send the response
+        await interaction.reply(msg)
+    },
+    options: {
+        // Used when the users problem was resolved
+        'yes': async function (interaction: ButtonInteraction) {
+            // Get the channel as a ThreadChannel
+            const thread = interaction.channel as ThreadChannel
+            // Get the first message in the thread
+            const start_message = await thread.fetchStarterMessage();
+            // Get the first 2 messages after the start message
+            const messages = await thread.messages.fetch({
+                limit: 2,
+                after: start_message.id,
+            });
+            // Filter the messages to find the bot message with the buttons
+            const bot_message = messages
+                .filter((m) => m.components.length > 0)
+                .first() as Message
+
+            // Create a reponse to the user
+            const msg = wrap_in_embed("Yay! In that case I'll go ahead and mark the thread as solved for you 🥳") as MessageOptions
+            // Send the response
+            await interaction.channel.send(msg)
+
+            try {
+                // Attempt to solve the channel
+                await solve_thread(thread);
+                // Change the message
+                const successMsg = wrap_in_embed(
+                    'Thread solved. Thank you everyone! 🥳',
+                ) as MessageEditOptions;
+                // Change the button
+                const row = new MessageActionRow().addComponents(
+                    new MessageButton()
+                        .setCustomId('reopen')
+                        .setLabel('Mark as Unsolved')
+                        .setStyle('SECONDARY')
+                        .setEmoji('❔'),
+                    ...bot_message.components[0].components.filter(val => val.customId !== 'solve')
+                )
+                successMsg.components = [row];
+                // Update the message
+                await bot_message.edit(successMsg)
+            } catch { }
+
+            // Create a MessageRow where the chosen interaction is disabled
+            const origRow = new MessageActionRow().addComponents(
+                new MessageButton()
+                    .setCustomId('auto_assist-start-yes')
+                    .setLabel('Yes')
+                    .setStyle('SUCCESS')
+                    .setEmoji('✅')
+                    .setDisabled(true)
+            )
+            // Update the original interaction message to make it clear which option the user picked
+            await interaction.update({ components: [origRow] })
+        },
+        // Used when the users issue wasn't resolved by the suggested solutions
+        'no': async function (interaction: ButtonInteraction) {
+            // Create a response message
+            let msg = wrap_in_embed("Seems like we've hit a dead end 😥\n\nPlease wait for a human to provide more assistance") as MessageOptions
+            // Send the message
+            await interaction.channel.send(msg)
+            // Create a MessageActionRow where the chosen action is disabled
+            const origRow = new MessageActionRow().addComponents(
+                new MessageButton()
+                    .setCustomId('auto_assist-start-no')
+                    .setLabel('No')
+                    .setStyle('DANGER')
+                    .setEmoji('⚠️')
+                    .setDisabled(true)
+            )
+            // Disable the chosen action
+            await interaction.update({ components: [origRow] })
+        },
+        // Used when no problems were found and the user should just be allowed to continue
+        'continue': async function (interaction: ButtonInteraction) {
+            // Create a response message
+            let msg = wrap_in_embed("Seems like we've hit a dead end 😥\n\nPlease wait for a human to provide more assistance") as MessageOptions
+            // Send the message
+            await interaction.channel.send(msg)
+            // Create a MessageActionRow where the chosen action is disabled
+            const origRow = new MessageActionRow().addComponents(
+                new MessageButton()
+                    .setCustomId('auto_assist-start-continue')
+                    .setLabel('Continue')
+                    .setStyle('PRIMARY')
+                    .setEmoji('▶️')
+                    .setDisabled(true)
+            )
+            // Disable the chosen action
+            await interaction.update({ components: [origRow] })
+        }
+    }
+}

--- a/src/modals/assist/start.ts
+++ b/src/modals/assist/start.ts
@@ -2,6 +2,7 @@ import { Modal, TextInputComponent, MessageActionRow, ModalSubmitInteraction, Me
 import { wrap_in_embed } from "../../utils/embed_helpers";
 import { solve_thread } from "../../utils/threads";
 import { MessageOptions } from "child_process";
+import fetch from "node-fetch";
 
 export const assistStartModal = {
     // Create a modal to show to the user
@@ -16,36 +17,59 @@ export const assistStartModal = {
     run: async function (interaction: ModalSubmitInteraction) {
         // Stores all problems found
         let problems: [Problem?] = []
-        // Current version of all dependencies (may need to find more and dynamically)
-        const currentVersion = '1.0.4'
+        // Metadata url
+        const metadataUrl = "https://raw.githubusercontent.com/tauri-apps/tauri/dev/tooling/cli/metadata.json"
+        const response = await fetch(metadataUrl, {
+            headers: {
+                Accept: 'application/json'
+            }
+        })
+        const metadata = await response.json() as LooseObject
+        // Npmjs url of the @tauri-apps/api package
+        const apiUrl = 'https://registry.npmjs.org/@tauri-apps/api'
+        // Get the api metadata
+        const res = await fetch(apiUrl, {
+            headers: {
+                Accept: 'application/vnd.npm.install-v1+json'
+            }
+        })
+        // Convert the response to json
+        const apiMeta = await res.json() as LooseObject
+        // Add the latest api version to the metadata object
+        metadata.api = Object.keys(apiMeta.versions).at(-1)
+
         // Get the tauri_info output from the modal
         const tauriInfoText = interaction.fields.getTextInputValue('tauri_info')
             .split('\n')
             .map(v => v.trim())
             .filter(v => v !== '')
         // Used to store the tauri_info as an object
-        let tauriInfo: LooseObject = {
-            environment: {},
-            packages: {},
-            app: {}
-        }
+        let tauriInfo: LooseObject = {}
         // Current section being handled
         let section = ''
         tauriInfoText.forEach((val) => {
             if (val === 'Environment') {
                 section = 'environment'
+                if (!(section in tauriInfo))
+                    tauriInfo[section] = {}
                 return
             }
             if (val === 'Packages') {
                 section = 'packages'
+                if (!(section in tauriInfo))
+                    tauriInfo[section] = {}
                 return
             }
             if (val === 'App') {
                 section = 'app'
+                if (!(section in tauriInfo))
+                    tauriInfo[section] = {}
                 return
             }
             if (val === 'App directory structure') {
                 section = 'appDirectoryStructure'
+                if (!(section in tauriInfo))
+                    tauriInfo[section] = {}
                 return
             }
             if (section === 'environment' && val.startsWith('›')) {
@@ -62,44 +86,54 @@ export const assistStartModal = {
             }
         })
 
-        // Check if tauri and tauri-build are the same versions
-        if (tauriInfo.packages['tauri [RUST]'] && tauriInfo.packages['tauri [RUST]'] !== tauriInfo.packages['tauri-build [RUST]']) {
+        // Check if any information is missing
+        if (!('environment' in tauriInfo) || !('packages' in tauriInfo) || !('app' in tauriInfo)) {
             problems.push({
-                info: `Your \`tauri\` and \`tauri-build\` dependencies versions do not appear to match, make sure they are both using \`${currentVersion}\``,
-                solutions: ['Edit `Cargo.toml` that all versions are correct', 'Run `cargo update`']
+                info: `Your \`tauri info\` output could not be parsed, did you enter it correctly?`,
+                solutions: ['Run `tauri info` retry asking for help']
             })
-        }
+        } else {
+            // Check if tauri and tauri-build are the same versions
+            /*
+            if (tauriInfo.packages['tauri [RUST]'] && tauriInfo.packages['tauri [RUST]'] !== tauriInfo.packages['tauri-build [RUST]']) {
+                problems.push({
+                    info: `Your \`tauri\` and \`tauri-build\` dependencies versions do not appear to match, make sure they are both using \`${metadata.tauri}\``,
+                    solutions: ['Edit `Cargo.toml` that all versions are correct', 'Run `cargo update`']
+                })
+            }
+            */
 
-        // Check if the CLI is the latest version
-        if (tauriInfo.packages['@tauri-apps/cli [NPM]'] && tauriInfo.packages['@tauri-apps/cli [NPM]'] !== currentVersion && tauriInfo.packages['@tauri-apps/cli [NPM]'] !== 'Not installed!') {
-            problems.push({
-                info: `\`@tauri-apps/cli [NPM]\` appears to be outdated, your version is \`${tauriInfo.packages['@tauri-apps/cli [NPM]']}\`, the current version is \`${currentVersion}\``,
-                solutions: ['Run `yarn add @tauri-apps/cli`']
-            })
-        }
+            // Check if the CLI is the latest version
+            if (tauriInfo.packages['@tauri-apps/cli [NPM]'] && tauriInfo.packages['@tauri-apps/cli [NPM]'] !== metadata['cli.js'].version && tauriInfo.packages['@tauri-apps/cli [NPM]'] !== 'Not installed!') {
+                problems.push({
+                    info: `\`@tauri-apps/cli [NPM]\` appears to be outdated, your version is \`${tauriInfo.packages['@tauri-apps/cli [NPM]']}\`, the current version is \`${metadata['cli.js'].version}\``,
+                    solutions: ['Run `yarn add @tauri-apps/cli`']
+                })
+            }
 
-        // Check if the API is the latest version
-        if (tauriInfo.packages['@tauri-apps/api [NPM]'] && tauriInfo.packages['@tauri-apps/api [NPM]'] !== currentVersion && tauriInfo.packages['@tauri-apps/api [NPM]'] !== 'Not installed!') {
-            problems.push({
-                info: `\`@tauri-apps/api\` [NPM] appears to be outdated, your version is \`${tauriInfo.packages['@tauri-apps/api [NPM]']}\`, the current version is \`${currentVersion}\``,
-                solutions: ['Run `yarn add @tauri-apps/api`']
-            })
-        }
+            // Check if the API is the latest version
+            if (tauriInfo.packages['@tauri-apps/api [NPM]'] && tauriInfo.packages['@tauri-apps/api [NPM]'] !== metadata.api && tauriInfo.packages['@tauri-apps/api [NPM]'] !== 'Not installed!') {
+                problems.push({
+                    info: `\`@tauri-apps/api\` [NPM] appears to be outdated, your version is \`${tauriInfo.packages['@tauri-apps/api [NPM]']}\`, the current version is \`${metadata.api}\``,
+                    solutions: ['Run `yarn add @tauri-apps/api`']
+                })
+            }
 
-        // Check if tauri is the latest version
-        if (tauriInfo.packages['tauri [RUST]'] && tauriInfo.packages['tauri [RUST]'] !== currentVersion) {
-            problems.push({
-                info: `\`tauri [RUST]\` appears to be outdated, your version is \`${tauriInfo.packages['tauri [RUST]']}\`, the current version is \`${currentVersion}\``,
-                solutions: ['Run `cargo update`']
-            })
-        }
+            // Check if tauri is the latest version
+            if (tauriInfo.packages['tauri [RUST]'] && tauriInfo.packages['tauri [RUST]'] !== metadata.tauri) {
+                problems.push({
+                    info: `\`tauri [RUST]\` appears to be outdated, your version is \`${tauriInfo.packages['tauri [RUST]']}\`, the current version is \`${metadata.tauri}\``,
+                    solutions: ['Run `cargo update`']
+                })
+            }
 
-        // Check if tauri-build is the latest version
-        if (tauriInfo.packages['tauri-build [RUST]'] && tauriInfo.packages['tauri-build [RUST]'] !== currentVersion) {
-            problems.push({
-                info: `\`tauri-build [RUST]\` appears to be outdated, your version is \`${tauriInfo.packages['tauri-build [RUST]']}\`, the current version is \`${currentVersion}\``,
-                solutions: ['Run `cargo update`']
-            })
+            // Check if tauri-build is the latest version
+            if (tauriInfo.packages['tauri-build [RUST]'] && tauriInfo.packages['tauri-build [RUST]'] !== metadata['tauri-build']) {
+                problems.push({
+                    info: `\`tauri-build [RUST]\` appears to be outdated, your version is \`${tauriInfo.packages['tauri-build [RUST]']}\`, the current version is \`${metadata['tauri-build']}\``,
+                    solutions: ['Run `cargo update`']
+                })
+            }
         }
 
         // Store the response text
@@ -139,6 +173,8 @@ export const assistStartModal = {
             // If there was text we ask an appropriate question based on what the next buttons are
             text = `${text}\n\n**Did this fix your issue?**`
         }
+        // Add the users tauri info output to the message
+        text = `${interaction.fields.getTextInputValue('tauri_info')}\n\n${text}`
         // Create the response message
         let msg = wrap_in_embed(text) as InteractionReplyOptions
         // Create the MessageActionRow

--- a/src/modals/index.ts
+++ b/src/modals/index.ts
@@ -1,0 +1,22 @@
+import { assistStartModal } from "./assist/start";
+
+// Getter for all available modals
+export function getModal(id: String) {
+    switch (id) {
+        case 'auto_assist-start': {
+            return assistStartModal
+        }
+    }
+}
+
+/*
+Assist modals are given custom ID's according to the following format:
+auto_assist-{MODAL}[-{ACTION}]
+So to get the start modal, you would do getModal('auto_assist-start')
+And in order to react to that modals actions, you would react to e.g. 'auto_assist-start-yes'
+*/
+export function getAssistModal(id: String) {
+    const mod = getModal(`auto_assist-${id}`)
+    mod.modal.setCustomId(`auto_assist-${id}`)
+    return mod
+}

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -1,0 +1,4 @@
+// Used when parsing the output of `tauri info`
+interface LooseObject {
+	[key: string]: any
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,5 @@
+// Used by the auto assist feature
+type Problem = {
+    info: string,
+    solutions: Array<string>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,10 +1204,10 @@ tslib@^2.4.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
-tsm@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/tsm/-/tsm-2.2.1.tgz"
-  integrity sha512-qvJB0baPnxQJolZru11mRgGTdNlx17WqgJnle7eht3Vhb+VUR4/zFA5hFl6NqRe7m8BD9w/6yu0B2XciRrdoJA==
+tsm@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tsm/-/tsm-2.2.2.tgz#0edacd62bbe53a87e8fc9c260ab65a7dbac5de06"
+  integrity sha512-bXkt675NbbqfwRHSSn8kSNEEHvoIUFDM9G6tUENkjEKpAEbrEzieO3PxUiRJylMw8fEGpcf5lSjadzzz12pc2A==
   dependencies:
     esbuild "^0.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@sapphire/async-queue@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz"
-  integrity sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g==
+"@sapphire/async-queue@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.3.2.tgz#befe5f5025e2e317a9eba2d1a24ca5d2e4576f86"
+  integrity sha512-rUpMLATsoAMnlN3gecAcr9Ecnw1vG7zi5Xr+IX22YzRzi1k9PF9vKzoT8RuEJbiIszjcimu3rveqUnvwDopz8g==
 
 "@sapphire/shapeshift@^3.5.1":
   version "3.5.1"
@@ -410,14 +410,14 @@ discord-api-types@^0.36.2:
   resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.36.2.tgz#2362bc544837be965ec99a5919f900c9699a7028"
   integrity sha512-TunPAvzwneK/m5fr4hxH3bMsrtI22nr9yjfHyo5NBGMjpsAauGNiGCmwoFf0oO3jSd2mZiKUvZwCKDaB166u2Q==
 
-discord.js@13.9.0:
-  version "13.9.0"
-  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.9.0.tgz#d2ff936a1536c8e7787d39437636d478e2dc6804"
-  integrity sha512-QNscX8lQ2FwHuAd/NptQYc43oMUVijugir/vRbsTSgySidg8pcGQVqtRg8urqY3cbCOCZfNAMD/lR+SM7uijsA==
+discord.js@13.9.1:
+  version "13.9.1"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.9.1.tgz#5cece5b539c2f4b08b61dd7255964278747b0880"
+  integrity sha512-vVKtSw0fT2ifEcCdI7+nfjEY3/wBfyls3L8Qo9uEhbAl1vCSXd7msskGyNIXzKqRUTz0R84UG10e8jmNxKIBLQ==
   dependencies:
     "@discordjs/builders" "^0.16.0"
     "@discordjs/collection" "^0.7.0"
-    "@sapphire/async-queue" "^1.3.1"
+    "@sapphire/async-queue" "^1.3.2"
     "@types/node-fetch" "^2.6.2"
     "@types/ws" "^8.5.3"
     discord-api-types "^0.33.3"


### PR DESCRIPTION
When user create a new help thread they can optionally click the button "Ask the bot for help" in order to initialize a conversation tree with the bot that hopefully helps resolve a lot of users most common issues.

Currently it is capable of parsing the output of the `tauri info` command in order to find some common issues, then it goes on to suggest a couple of places the user can look for solutions to their issue. At the end if the issue wasn't resolved it pings the Helping Hand role in order to raise awareness of the issue, kinda like a reward for having actually gone through the most basic debugging steps.