### PR TITLE
Removed wrapping in embed to fix following links on mobile

### DIFF
--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -44,13 +44,14 @@ export default command({
                             ? interaction.channel
                             : interaction.channel.parent;
                     // Filter all threads based on the channel the command was ran in
-                    let listThreads = threads
-                        .filter(
-                            (thread) => thread.parentId === parentChannel.id,
+                    let listThreads = threads.filter(
+                        (thread) => thread.parentId === parentChannel.id,
+                    );
+                    if (HELP_THREAD_CHANNELS.includes(parentChannel.id)) {
+                        listThreads = listThreads.filter((thread) =>
+                            thread.name.startsWith('❔'),
                         );
-					if (HELP_THREAD_CHANNELS.includes(parentChannel.id)) {
-						listThreads = listThreads.filter((thread)=>thread.name.startsWith('❔'))
-					}
+                    }
                     // Set a title for the DM
                     let message = `**Here's a list of all currently active threads in <#${parentChannel.id}>**\n`;
                     if (listThreads.length === 0) {
@@ -62,7 +63,7 @@ export default command({
                             .join('\n');
                     }
                     // Send the message to the user
-                    await interaction.followUp(wrap_in_embed(message));
+                    await interaction.followUp(message);
                     break;
                 }
             }


### PR DESCRIPTION
Currently because we wrap messages in embed to make the bots messages prettier it ruins the ability to follow links on mobile devices because the click goes to the embed instead of the channel link.

To fix this, at least for the `/threads list` command, I removed the wrapping.